### PR TITLE
jsonスキーマの更新(torimon)

### DIFF
--- a/src/store/modules/MapViewModule.ts
+++ b/src/store/modules/MapViewModule.ts
@@ -62,7 +62,6 @@ export class MapViewModule extends VuexModule implements MapViewState {
                     id:       spot.id,
                     name:     spot.name,
                     coordinate: spot.coordinate,
-                    floor:    spot.floor,
                     shape:    spot.shape,
                 });
             });

--- a/src/store/modules/MapViewModule.ts
+++ b/src/store/modules/MapViewModule.ts
@@ -62,7 +62,6 @@ export class MapViewModule extends VuexModule implements MapViewState {
                     id:       spot.id,
                     name:     spot.name,
                     coordinate: spot.coordinate,
-                    floor:    spot.floor,
                 });
             });
             return spotsForMap;
@@ -77,7 +76,6 @@ export class MapViewModule extends VuexModule implements MapViewState {
         const spot: Spot = this.maps[this.focusedMapId].spots[this.focusedSpotId];
         const spotInfo: SpotInfo = {
             name:  spot.name,
-            floor: spot.floor,
         };
         return spotInfo;
     }

--- a/src/store/modules/sampleMaps.ts
+++ b/src/store/modules/sampleMaps.ts
@@ -47,7 +47,7 @@ export const sampleMaps: Map[] =  [
                     ] ],
                 },
                 gateNodeIds: [],
-                detailMapId: 1,
+                detailMapIds: [1],
             },
         ],
         bounds: {

--- a/src/store/modules/sampleMaps.ts
+++ b/src/store/modules/sampleMaps.ts
@@ -7,12 +7,11 @@ export const sampleMaps: Map[] =  [
         spots: [
             {
                 id: 0,
-                name: 'SougouGakusyuPlaza',
+                name: 'SougouGakusyuPlazaFloor',
                 coordinate: {
                     lat: 33.595502,
                     lng: 130.218238,
                 },
-                floor: 1,
                 shape: {
                     type: 'Polygon',
                     coordinates: [[
@@ -48,6 +47,7 @@ export const sampleMaps: Map[] =  [
                 },
                 gateNodeIds: [],
                 detailMapIds: [1],
+                detailMapLevelNames: [],
             },
         ],
         bounds: {
@@ -84,7 +84,6 @@ export const sampleMaps: Map[] =  [
                         ],
                     ],
                 },
-                floor: 1,
                 gateNodeIds: [],
             },
         ],

--- a/src/store/modules/sampleMaps.ts
+++ b/src/store/modules/sampleMaps.ts
@@ -7,7 +7,7 @@ export const sampleMaps: Map[] =  [
         spots: [
             {
                 id: 0,
-                name: 'SougouGakusyuPlazaFloor',
+                name: 'SougouGakusyuPlaza',
                 coordinate: {
                     lat: 33.595502,
                     lng: 130.218238,
@@ -64,7 +64,7 @@ export const sampleMaps: Map[] =  [
     },
     {
         id: 1,
-        name: 'SougouGakusyuPlaza',
+        name: 'SougouGakusyuPlaza_1F',
         spots: [
             {
                 id: 0,
@@ -85,6 +85,44 @@ export const sampleMaps: Map[] =  [
                     ],
                 },
                 gateNodeIds: [],
+            },
+        ],
+        bounds: {
+            topL: {
+                lat: 33.5954678,
+                lng: 130.2177802,
+            },
+            botR: {
+                lat: 33.5954678,
+                lng: 130.2177802,
+            },
+        },
+    },
+    {
+        id: 1,
+        name: 'SougouGakusyuPlaza_2F',
+        spots: [
+            {
+                id: 10,
+                name: '201',
+                coordinate: {
+                    lat: 33.5954558,
+                    lng: 130.2179447,
+                },
+                shape: {
+                    type: 'Polygon',
+                    coordinates: [
+                        [
+                            [130.217816, 33.595257],
+                            [130.217783, 33.595517],
+                            [130.217915, 33.595558],
+                            [130.217942, 33.595495],
+                        ],
+                    ],
+                },
+                gateNodeIds: [10],
+                detailMapIds: [],
+                others: {},
             },
         ],
         bounds: {

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -54,7 +54,6 @@ export interface SpotForMap {
     id: number;
     name: string;
     coordinate: Coordinate;
-    floor: number;
     shape?: Shape;
 }
 

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -37,7 +37,8 @@ export interface Spot {
         'coordinates': number[][][] | number[][][][],
     };
     gateNodeIds: number[];
-    detailMapId?: number;
+    detailMapIds?: number[];
+    detailMapLevelNames?: string[];
     others?: any;
 }
 

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -27,7 +27,6 @@ export interface Spot {
     id: number;
     name: string;
     coordinate: Coordinate;
-    floor: number;
     /**
      * GeoJSONのジオメトリオブジェクトのJSON構造
      * [GeoJSON フォーマット仕様](https://s.kitazaki.name/docs/geojson-spec-ja.html#id5)
@@ -48,7 +47,6 @@ export interface Spot {
  */
 export interface SpotInfo {
     name: string;
-    floor: number;
     others?: any;
 }
 
@@ -59,7 +57,6 @@ export interface SpotForMap {
     id: number;
     name: string;
     coordinate: Coordinate;
-    floor: number;
 }
 
 /**

--- a/tests/unit/mapDisplayPolygons.spec.ts
+++ b/tests/unit/mapDisplayPolygons.spec.ts
@@ -18,7 +18,6 @@ const mapViewStateTestData: MapViewState = {
                         lat: 33.595502,
                         lng: 130.218238,
                     },
-                    floor: 1,
                     shape: {
                         type: 'Polygon',
                         coordinates: [[
@@ -32,7 +31,7 @@ const mapViewStateTestData: MapViewState = {
                         ]],
                     },
                     gateNodeIds: [],
-                    detailMapId: 1,
+                    detailMapIds: [1],
                 },
             ],
             bounds: {
@@ -67,7 +66,6 @@ const mapViewStateTestData: MapViewState = {
                                 [130.217942, 33.595495],
                             ]],
                     },
-                    floor: 1,
                     gateNodeIds: [],
                 },
             ],

--- a/tests/unit/store/modules/MapViewModule.spec.ts
+++ b/tests/unit/store/modules/MapViewModule.spec.ts
@@ -168,7 +168,6 @@ describe('components/SpotInfo.vue', () => {
                 id:       expectedMapViewState.maps[0].spots[0].id,
                 name:     expectedMapViewState.maps[0].spots[0].name,
                 coordinate: expectedMapViewState.maps[0].spots[0].coordinate,
-                floor:    expectedMapViewState.maps[0].spots[0].floor,
                 shape:    expectedMapViewState.maps[0].spots[0].shape,
             },
         ];

--- a/tests/unit/store/modules/MapViewModule.spec.ts
+++ b/tests/unit/store/modules/MapViewModule.spec.ts
@@ -49,7 +49,7 @@ const expectedMapViewState: MapViewState = {
                         ] ],
                     },
                     gateNodeIds: [],
-                    detailMapId: 1,
+                    detailMapIds: [1],
                 },
             ],
             bounds: {

--- a/tests/unit/store/modules/MapViewModule.spec.ts
+++ b/tests/unit/store/modules/MapViewModule.spec.ts
@@ -14,7 +14,6 @@ const expectedMapViewState: MapViewState = {
                         lat: 33.595502,
                         lng: 130.218238,
                     },
-                    floor: 1,
                     shape: {
                         type: 'Polygon',
                         coordinates: [[
@@ -62,11 +61,10 @@ const expectedMapViewState: MapViewState = {
                     lng: 130.220609,
                 },
             },
-
         },
         {
             id: 1,
-            name: 'SougouGakusyuPlaza',
+            name: 'SougouGakusyuPlaza_1F',
             spots: [
                 {
                     id: 0,
@@ -86,8 +84,45 @@ const expectedMapViewState: MapViewState = {
                             ],
                         ],
                     },
-                    floor: 1,
                     gateNodeIds: [],
+                },
+            ],
+            bounds: {
+                topL: {
+                    lat: 33.5954678,
+                    lng: 130.2177802,
+                },
+                botR: {
+                    lat: 33.5954678,
+                    lng: 130.2177802,
+                },
+            },
+        },
+        {
+            id: 1,
+            name: 'SougouGakusyuPlaza_2F',
+            spots: [
+                {
+                    id: 10,
+                    name: '201',
+                    coordinate: {
+                        lat: 33.5954558,
+                        lng: 130.2179447,
+                    },
+                    shape: {
+                        type: 'Polygon',
+                        coordinates: [
+                            [
+                                [130.217816, 33.595257],
+                                [130.217783, 33.595517],
+                                [130.217915, 33.595558],
+                                [130.217942, 33.595495],
+                            ],
+                        ],
+                    },
+                    gateNodeIds: [10],
+                    detailMapIds: [],
+                    others: {},
                 },
             ],
             bounds: {
@@ -133,7 +168,6 @@ describe('components/SpotInfo.vue', () => {
                 id:       expectedMapViewState.maps[0].spots[0].id,
                 name:     expectedMapViewState.maps[0].spots[0].name,
                 coordinate: expectedMapViewState.maps[0].spots[0].coordinate,
-                floor:    expectedMapViewState.maps[0].spots[0].floor,
             },
         ];
         expect(actualSpotsForMap).toEqual(expectedSpotsForMap);
@@ -145,7 +179,6 @@ describe('components/SpotInfo.vue', () => {
         const expectedFocusedSpotId: number = expectedMapViewState.focusedSpotId;
         const expectedInfoOfCurrentSpot: SpotInfo = {
             name:  expectedMapViewState.maps[expectedFocusedMapId].spots[expectedFocusedSpotId].name,
-            floor: expectedMapViewState.maps[expectedFocusedMapId].spots[expectedFocusedSpotId].floor,
         };
         expect(actualInfoOfCurrentSpot).toEqual(expectedInfoOfCurrentSpot);
     });

--- a/tests/unit/store/modules/MapViewModule.spec.ts
+++ b/tests/unit/store/modules/MapViewModule.spec.ts
@@ -45,7 +45,7 @@ const expectedMapViewState: MapViewState = {
                                 130.21780639886853,
                                 33.59551018989406,
                             ],
-                        ] ],
+                        ]],
                     },
                     gateNodeIds: [],
                     detailMapIds: [1],
@@ -99,7 +99,7 @@ const expectedMapViewState: MapViewState = {
             },
         },
         {
-            id: 1,
+            id: 2,
             name: 'SougouGakusyuPlaza_2F',
             spots: [
                 {


### PR DESCRIPTION
## 実装の概要
- スポットがもっているdetailMapIdをdetailMapIdsにして配列にする
- スポットに，そのスポットがもっている詳細地図の階層情報の一覧を追加
  - Stringの配列　（['B1', '1F', '2F', '3F']など）
- Notionの更新 [地図データの仕様](https://www.notion.so/7a6a9ce29e974d5ab2e7d5dfc7f7df2d)
- vue側のtypesの更新: detailMapLevelNames

close #64