### PR TITLE
spotHasDetailMaps()とテストの作成

### DIFF
--- a/src/store/modules/MapViewModule.ts
+++ b/src/store/modules/MapViewModule.ts
@@ -86,19 +86,32 @@ export class MapViewModule extends VuexModule implements MapViewState {
     }
 
     /**
-     * 指定されたスポットが詳細マップを持つかどうかを判定する
+     * 指定されたスポットが詳細マップを持つかどうかを判定する．
+     * 存在しないMapIdやSpotIdを指定すると例外を投げる．
      * @param parentSpot マップのIdとスポットのId
      * @return スポットが詳細マップを持つならばtrue, 持たないならばfalse
+     * @throw Error Mapが存在しない場合に発生
+     * @throw Error Spotが存在しない場合に発生
      */
-    get hasDetailMaps() {
+    get spotHasDetailMaps() {
         return (
-            panretSpot: {
+            parentSpot: {
                 parentMapId: number,
                 spotId: number,
             },
         ): boolean => {
-            const map: Map = this.maps[panretSpot.parentMapId];
-            const spot: Spot = map.spots[panretSpot.spotId];
+            const map: Map | undefined = this.maps.find((m: Map) => m.id === parentSpot.parentMapId);
+            if (map === undefined) {
+                // errors.tsがマージされたらmapNotFoundErrorに置き換える
+                throw new Error('Map Not Found...');
+            }
+
+            const spot: Spot | undefined = map.spots.find((s: Spot) => s.id === parentSpot.spotId);
+            if (spot === undefined) {
+                // errors.tsがマージされたらspotNotFoundErrorに置き換える
+                throw new Error('Spot Not Found...');
+            }
+
             if (spot.detailMapIds.length > 0) {
                 return true;
             } else {

--- a/src/store/modules/MapViewModule.ts
+++ b/src/store/modules/MapViewModule.ts
@@ -95,18 +95,18 @@ export class MapViewModule extends VuexModule implements MapViewState {
      */
     get spotHasDetailMaps() {
         return (
-            parentSpot: {
+            targetSpot: {
                 parentMapId: number,
                 spotId: number,
             },
         ): boolean => {
-            const map: Map | undefined = this.maps.find((m: Map) => m.id === parentSpot.parentMapId);
+            const map: Map | undefined = this.maps.find((m: Map) => m.id === targetSpot.parentMapId);
             if (map === undefined) {
                 // errors.tsがマージされたらmapNotFoundErrorに置き換える
                 throw new Error('Map Not Found...');
             }
 
-            const spot: Spot | undefined = map.spots.find((s: Spot) => s.id === parentSpot.spotId);
+            const spot: Spot | undefined = map.spots.find((s: Spot) => s.id === targetSpot.spotId);
             if (spot === undefined) {
                 // errors.tsがマージされたらspotNotFoundErrorに置き換える
                 throw new Error('Spot Not Found...');

--- a/src/store/modules/MapViewModule.ts
+++ b/src/store/modules/MapViewModule.ts
@@ -84,6 +84,29 @@ export class MapViewModule extends VuexModule implements MapViewState {
         };
         return spotInfo;
     }
+
+    /**
+     * 指定されたスポットが詳細マップを持つかどうかを判定する
+     * @param parentSpot マップのIdとスポットのId
+     * @return スポットが詳細マップを持つならばtrue, 持たないならばfalse
+     */
+    get hasDetailMaps() {
+        return (
+            panretSpot: {
+                parentMapId: number,
+                spotId: number,
+            },
+        ): boolean => {
+            const map: Map = this.maps[panretSpot.parentMapId];
+            const spot: Spot = map.spots[panretSpot.spotId];
+            if (spot.detailMapIds.length > 0) {
+                return true;
+            } else {
+                return false;
+            }
+        };
+    }
+
     /**
      * スポットの詳細マップのどの階層が表示されているかをMapIdで返す
      * 無ければ例外を返す

--- a/src/store/modules/sampleMaps.ts
+++ b/src/store/modules/sampleMaps.ts
@@ -85,6 +85,7 @@ export const sampleMaps: Map[] =  [
                     ],
                 },
                 gateNodeIds: [],
+                detailMapIds: [],
             },
         ],
         bounds: {

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -36,7 +36,7 @@ export interface Spot {
      */
     shape?: Shape;
     gateNodeIds: number[];
-    detailMapIds?: number[];
+    detailMapIds: number[];
     detailMapLevelNames?: string[];
     others?: any;
 }

--- a/tests/unit/mapDisplayPolygons.spec.ts
+++ b/tests/unit/mapDisplayPolygons.spec.ts
@@ -67,6 +67,7 @@ const mapViewStateTestData: MapViewState = {
                             ]],
                     },
                     gateNodeIds: [],
+                    detailMapIds: [],
                 },
             ],
             bounds: {

--- a/tests/unit/mapSwitchMarkers.spec.ts
+++ b/tests/unit/mapSwitchMarkers.spec.ts
@@ -93,6 +93,7 @@ const MapViewStoreTestData: MapViewState = {
                         ],
                     },
                     gateNodeIds: [],
+                    detailMapIds: [],
                 },
             ],
             bounds: {

--- a/tests/unit/store/modules/MapViewModule.spec.ts
+++ b/tests/unit/store/modules/MapViewModule.spec.ts
@@ -85,6 +85,7 @@ const expectedMapViewState: MapViewState = {
                         ],
                     },
                     gateNodeIds: [],
+                    detailMapIds: [],
                 },
             ],
             bounds: {
@@ -185,6 +186,26 @@ describe('store/modules/MapViewModule.ts', () => {
             name:  expectedMapViewState.maps[expectedFocusedMapId].spots[expectedFocusedSpotId].name,
         };
         expect(actualInfoOfFocusedSpot).toEqual(expectedInfoOfFocusedSpot);
+    });
+
+    it('hasDetailMaps()で詳細マップを持つかどうかを判定する', () => {
+        // 詳細マップを持っている場合
+        const expectedValWithDetailMaps: boolean = true;
+        const parentSpotWithDetailMaps = {
+            parentMapId: 0,
+            spotId: 0,
+        };
+        const actualValWithDetailMaps: boolean = mapViewStore.hasDetailMaps(parentSpotWithDetailMaps);
+        expect(actualValWithDetailMaps).toBe(expectedValWithDetailMaps);
+
+        // 詳細マップを持っていない場合
+        const expectedValWithoutDetailMaps: boolean = false;
+        const parentSpotWithoutDetailMaps = {
+            parentMapId: 1,
+            spotId: 0,
+        };
+        const actualValWithoutDetailMaps: boolean = mapViewStore.hasDetailMaps(parentSpotWithoutDetailMaps);
+        expect(actualValWithoutDetailMaps).toBe(expectedValWithoutDetailMaps);
     });
 
     it('setterでsetしたFocusedSpotがmapViewStoreのstateに登録されている', () => {

--- a/tests/unit/store/modules/MapViewModule.spec.ts
+++ b/tests/unit/store/modules/MapViewModule.spec.ts
@@ -198,40 +198,40 @@ describe('store/modules/MapViewModule.ts', () => {
     it('spotHasDetailMaps()で詳細マップを持つかどうかを判定する', () => {
         // 詳細マップを持っている場合
         const expectedValWithDetailMaps: boolean = true;
-        const parentSpotWithDetailMaps = {
+        const targetSpotWithDetailMaps = {
             parentMapId: 0,
             spotId: 0,
         };
-        const actualValWithDetailMaps: boolean = mapViewStore.spotHasDetailMaps(parentSpotWithDetailMaps);
+        const actualValWithDetailMaps: boolean = mapViewStore.spotHasDetailMaps(targetSpotWithDetailMaps);
         expect(actualValWithDetailMaps).toBe(expectedValWithDetailMaps);
 
         // 詳細マップを持っていない場合
         const expectedValWithoutDetailMaps: boolean = false;
-        const parentSpotWithoutDetailMaps = {
+        const targetSpotWithoutDetailMaps = {
             parentMapId: 2,
             spotId: 10,
         };
-        const actualValWithoutDetailMaps: boolean = mapViewStore.spotHasDetailMaps(parentSpotWithoutDetailMaps);
+        const actualValWithoutDetailMaps: boolean = mapViewStore.spotHasDetailMaps(targetSpotWithoutDetailMaps);
         expect(actualValWithoutDetailMaps).toBe(expectedValWithoutDetailMaps);
     });
 
     it('spotHasDetailMaps()の例外処理', () => {
         // マップが存在しない場合
-        const parentSpotWithDetailMaps = {
+        const targetSpotWithDetailMaps = {
             parentMapId: 999,
             spotId: 0,
         };
         expect(() => {
-            const _ = mapViewStore.spotHasDetailMaps(parentSpotWithDetailMaps);
+            const _ = mapViewStore.spotHasDetailMaps(targetSpotWithDetailMaps);
         }).toThrow(Error);
 
         // スポットが存在しない場合
-        const parentSpotWithoutDetailMaps = {
+        const targetSpotWithoutDetailMaps = {
             parentMapId: 0,
             spotId: 999,
         };
         expect(() => {
-            const _ = mapViewStore.spotHasDetailMaps(parentSpotWithoutDetailMaps);
+            const _ = mapViewStore.spotHasDetailMaps(targetSpotWithoutDetailMaps);
         }).toThrow(Error);
     });
 

--- a/tests/unit/store/modules/MapViewModule.spec.ts
+++ b/tests/unit/store/modules/MapViewModule.spec.ts
@@ -188,24 +188,44 @@ describe('store/modules/MapViewModule.ts', () => {
         expect(actualInfoOfFocusedSpot).toEqual(expectedInfoOfFocusedSpot);
     });
 
-    it('hasDetailMaps()で詳細マップを持つかどうかを判定する', () => {
+    it('spotHasDetailMaps()で詳細マップを持つかどうかを判定する', () => {
         // 詳細マップを持っている場合
         const expectedValWithDetailMaps: boolean = true;
         const parentSpotWithDetailMaps = {
             parentMapId: 0,
             spotId: 0,
         };
-        const actualValWithDetailMaps: boolean = mapViewStore.hasDetailMaps(parentSpotWithDetailMaps);
+        const actualValWithDetailMaps: boolean = mapViewStore.spotHasDetailMaps(parentSpotWithDetailMaps);
         expect(actualValWithDetailMaps).toBe(expectedValWithDetailMaps);
 
         // 詳細マップを持っていない場合
         const expectedValWithoutDetailMaps: boolean = false;
         const parentSpotWithoutDetailMaps = {
-            parentMapId: 1,
+            parentMapId: 2,
+            spotId: 10,
+        };
+        const actualValWithoutDetailMaps: boolean = mapViewStore.spotHasDetailMaps(parentSpotWithoutDetailMaps);
+        expect(actualValWithoutDetailMaps).toBe(expectedValWithoutDetailMaps);
+    });
+
+    it('spotHasDetailMaps()の例外処理', () => {
+        // マップが存在しない場合
+        const parentSpotWithDetailMaps = {
+            parentMapId: 999,
             spotId: 0,
         };
-        const actualValWithoutDetailMaps: boolean = mapViewStore.hasDetailMaps(parentSpotWithoutDetailMaps);
-        expect(actualValWithoutDetailMaps).toBe(expectedValWithoutDetailMaps);
+        expect(() => {
+            const _ = mapViewStore.spotHasDetailMaps(parentSpotWithDetailMaps);
+        }).toThrow(Error);
+
+        // スポットが存在しない場合
+        const parentSpotWithoutDetailMaps = {
+            parentMapId: 0,
+            spotId: 999,
+        };
+        expect(() => {
+            const _ = mapViewStore.spotHasDetailMaps(parentSpotWithoutDetailMaps);
+        }).toThrow(Error);
     });
 
     it('setterでsetしたFocusedSpotがmapViewStoreのstateに登録されている', () => {


### PR DESCRIPTION
# 実装の概要
- ~`hasDetailMaps()`~`spotHasDetailMaps()`の作成
スポットが詳細マップを持つかどうかを判定するgetter．
持つ場合は`true`，持たない場合は`false`を返す．
存在しないマップやスポットを引数に渡すと例外を投げる.
- ~`hasDetailMaps()`~`spotHasDetailMaps()`のテスト作成
   - スポットがdetailMapを持つ場合と持たない場合をチェック.
   - マップ，スポットが存在しない場合の例外をチェック．

close #92 
