### PR TITLE
現在表示するマップのIDをvuexに追加

### DIFF
--- a/src/store/modules/MapViewModule.ts
+++ b/src/store/modules/MapViewModule.ts
@@ -74,6 +74,11 @@ export class MapViewModule extends VuexModule implements MapViewState {
      */
     public displayLevel: DisplayLevelType = 'default';
 
+    /** 
+     * MapView上でスポットアイコンやポリゴンが表示されるマップのID
+     */
+    public mapIdToDisplay: number = this.rootMapId;
+
     /**
      * Mapコンポーネントが扱うマップの範囲を返す
      * @return マップの範囲
@@ -198,6 +203,16 @@ export class MapViewModule extends VuexModule implements MapViewState {
     }
 
     /**
+     * MapView上でスポットアイコンやポリゴンが表示されるマップのIDを返す
+     * @return マップID
+     */
+    get getMapIdToDisplay() {
+        return (): number => {
+            return this.mapIdToDisplay;
+        }
+    }
+
+    /**
      * Mapコンポーネント上でフォーカスされているスポットのIDを更新する
      * @param newFocusedSpot 新しくフォーカスされるスポット
      * 中にmapId, spotIdを持つ
@@ -262,6 +277,16 @@ export class MapViewModule extends VuexModule implements MapViewState {
     @Mutation
     public setNonExistentOfCenterSpotWithDetailMap(): void {
         this.idOfCenterSpotWithDetailMap = null;
+    }
+
+    /**
+     * Mapコンポーネントでポリゴンやスポットマーカーが表示されることになる  
+     * マップのIDを更新する 
+     * @param newMapIdToDisplay 新しくセットするマップID
+     */
+    @Mutation
+    public setMapIdToDisplay(newMapIdToDisplay: number): void {
+        this.mapIdToDisplay = newMapIdToDisplay; 
     }
 
     /**

--- a/src/store/modules/MapViewModule.ts
+++ b/src/store/modules/MapViewModule.ts
@@ -74,7 +74,7 @@ export class MapViewModule extends VuexModule implements MapViewState {
      */
     public displayLevel: DisplayLevelType = 'default';
 
-    /** 
+    /**
      * MapView上でスポットアイコンやポリゴンが表示されるマップのID
      */
     public mapIdToDisplay: number = this.rootMapId;
@@ -209,7 +209,7 @@ export class MapViewModule extends VuexModule implements MapViewState {
     get getMapIdToDisplay() {
         return (): number => {
             return this.mapIdToDisplay;
-        }
+        };
     }
 
     /**
@@ -280,13 +280,13 @@ export class MapViewModule extends VuexModule implements MapViewState {
     }
 
     /**
-     * Mapコンポーネントでポリゴンやスポットマーカーが表示されることになる  
-     * マップのIDを更新する 
+     * Mapコンポーネントでポリゴンやスポットマーカーが表示されることになる
+     * マップのIDを更新する
      * @param newMapIdToDisplay 新しくセットするマップID
      */
     @Mutation
     public setMapIdToDisplay(newMapIdToDisplay: number): void {
-        this.mapIdToDisplay = newMapIdToDisplay; 
+        this.mapIdToDisplay = newMapIdToDisplay;
     }
 
     /**

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -11,6 +11,7 @@ export interface MapViewState {
     spotInfoIsVisible: boolean;
     displayLevel: DisplayLevelType;
     idOfCenterSpotWithDetailMap: number | null;
+    mapIdToDisplay: number;
 }
 
 /**

--- a/tests/resources/testMapViewState.ts
+++ b/tests/resources/testMapViewState.ts
@@ -154,5 +154,6 @@ export const testMapViewState: MapViewState = {
     spotInfoIsVisible: false,
     displayLevel: 'default',
     idOfCenterSpotWithDetailMap: 0,
+    mapIdToDisplay: 0,
 };
 

--- a/tests/unit/store/modules/MapViewModule.spec.ts
+++ b/tests/unit/store/modules/MapViewModule.spec.ts
@@ -102,16 +102,6 @@ describe('store/modules/MapViewModule.ts', () => {
         }).toThrow(SpotNotFoundError);
     });
 
-    it('setterでsetしたFocusedSpotがmapViewStoreのstateに登録されている', () => {
-        const expectedNewFocusedSpot: {mapId: number, spotId: number} = {
-            mapId: 1,
-            spotId: 0,
-        };
-        mapViewStore.setFocusedSpot(expectedNewFocusedSpot);
-        const actualFocusedSpot: {mapId: number, spotId: number} = mapViewStore.focusedSpot;
-        expect(actualFocusedSpot).toBe(expectedNewFocusedSpot);
-    });
-
     it('getLastViewedDetailMapIdでスポットの参照された詳細マップIdを取得する', () => {
         // lastViewdDetailMapIdの初期値はnullである
         const expectedLastViewedDetailMapId: null = null;
@@ -133,9 +123,30 @@ describe('store/modules/MapViewModule.ts', () => {
         }).toThrow(NoDetailMapsError);
     });
 
+    it('stateのdisplayLevelをgetterで取得する', () => {
+        // テストデータの初期値はdefault
+        const expectedDisplayLevel: DisplayLevelType = 'default';
+        expect(mapViewStore.getDisplayLevel()).toBe(expectedDisplayLevel);
+    });
+
     it('stateに登録したidOfCenterSpotWithDetailMapを取得する', () => {
         const expectedId: number | null = expectedMapViewState.idOfCenterSpotWithDetailMap;
         expect(mapViewStore.getIdOfCenterSpotWithDetailMap()).toBe(expectedId);
+    });
+
+    it('stateに登録したmapIdToDisplayを取得する', () => {
+        const expectedMapId: number = expectedMapViewState.mapIdToDisplay;
+        expect(mapViewStore.getMapIdToDisplay()).toBe(expectedMapId);
+    });
+
+    it('setterでsetしたFocusedSpotがmapViewStoreのstateに登録されている', () => {
+        const expectedNewFocusedSpot: {mapId: number, spotId: number} = {
+            mapId: 1,
+            spotId: 0,
+        };
+        mapViewStore.setFocusedSpot(expectedNewFocusedSpot);
+        const actualFocusedSpot: {mapId: number, spotId: number} = mapViewStore.focusedSpot;
+        expect(actualFocusedSpot).toBe(expectedNewFocusedSpot);
     });
 
     it('スポットに存在しない詳細マップをlastViewDetaiMapIdにセットしようとすると例外が発生する', () => {
@@ -174,6 +185,12 @@ describe('store/modules/MapViewModule.ts', () => {
         expect(actualDetailMapId).toBe(expectedDetailMapId);
     });
 
+    it('setしたnewDisplayLevelがstateに登録されている', () => {
+        const newDisplayLevel: DisplayLevelType = 'detail';
+        mapViewStore.setDisplayLevel(newDisplayLevel);
+        expect(mapViewStore.displayLevel).toBe(newDisplayLevel);
+    });
+
     it('setIdOfCenterSpotWithDetailMap()でsetしたidOfCenterSpotWithDetailMapがmapViewStoreのstateに登録されている', () => {
         const expectedIdOfCenterSpotWithDetailMap = 1;
         mapViewStore.setIdOfCenterSpotWithDetailMap(expectedIdOfCenterSpotWithDetailMap);
@@ -185,15 +202,9 @@ describe('store/modules/MapViewModule.ts', () => {
         expect(mapViewStore.idOfCenterSpotWithDetailMap).toBe(null);
     });
 
-    it('setしたnewDisplayLevelがstateに登録されている', () => {
-        const newDisplayLevel: DisplayLevelType = 'detail';
-        mapViewStore.setDisplayLevel(newDisplayLevel);
-        expect(mapViewStore.displayLevel).toBe(newDisplayLevel);
-    });
-
-    it('stateのdisplayLevelをgetterで取得する', () => {
-        // テストデータの初期値はdefault
-        const expectedDisplayLevel: DisplayLevelType = 'default';
-        expect(mapViewStore.getDisplayLevel()).toBe(expectedDisplayLevel);
+    it('setしたnewMapIdToDisplayがstateに登録されている', () => {
+        const newMapIdToDisplay: number = 1;
+        mapViewStore.setMapIdToDisplay(newMapIdToDisplay);
+        expect(mapViewStore.mapIdToDisplay).toBe(newMapIdToDisplay);
     });
 });


### PR DESCRIPTION
## 実装の概要
- stateとしてmapIdToDisplayを追加し，getterとmutationを作成
- MapViewModuleのテストの並びをメソッドの並びと統一

close #116 
