### PR TITLE
マップの初期描画部分を関数に分離

### DIFF
--- a/src/components/Map/index.ts
+++ b/src/components/Map/index.ts
@@ -42,24 +42,18 @@ export default class Map extends Vue {
                 maxNativeZoom: 19,
             },
         ).addTo(this.map);
+        this.map.on('zoomend', this.updateDisplayLevel);
+        this.map.on('move', this.updateIdOfCenterSpotInRootMap);
+        this.initMapDisplay();
+    }
 
+    private initMapDisplay(): void {
         // sampleMapのスポット表示
         const rootMapSpots: SpotForMap[] = mapViewGetters.getSpotsForMap(mapViewGetters.rootMapId);
         this.displaySpotMarkers(rootMapSpots);
-
         // sampleMapのポリゴン表示
-        // $nextTick()はテスト実行時のエラーを回避するために使用しています．
-        this.$nextTick().then(() => {
-            this.displayPolygons(rootMapSpots);
-            // 経路（エッジ）表示
-            this.displayRouteLines(mapViewGetters.getNodesForNavigation([]));
-            // 経路レイヤーが消去されているか確認
-            // this.routeLines = this.displayRouteLines([]);
-        });
+        this.displayPolygons(rootMapSpots);
         this.currentLocationMarker.addTo(this.map);
-
-        this.map.on('zoomend', this.updateDisplayLevel);
-        this.map.on('move', this.updateIdOfCenterSpotInRootMap);
     }
 
     /**

--- a/src/components/Map/index.ts
+++ b/src/components/Map/index.ts
@@ -47,6 +47,9 @@ export default class Map extends Vue {
         this.initMapDisplay();
     }
 
+    /**
+     * マップの初期の描画，モックするためにmountedから分離
+     */
     private initMapDisplay(): void {
         // sampleMapのスポット表示
         const rootMapSpots: SpotForMap[] = mapViewGetters.getSpotsForMap(mapViewGetters.rootMapId);

--- a/tests/unit/components/Map/MapUpdateIdOfCenterSpot.spec.ts
+++ b/tests/unit/components/Map/MapUpdateIdOfCenterSpot.spec.ts
@@ -25,8 +25,12 @@ describe('中央に最も近いスポットの取得，およびその更新の�
         // テスト用データをstoreにセット
         mapViewMutations.setMapViewState(mapViewStateTestData);
         GeolocationWrapper.watchPosition = jest.fn();
+        const initMapDisplay = jest.fn();
         wrapper = shallowMount( map, {
             attachToDocument: true,
+            methods: {
+                initMapDisplay,
+            },
         });
     });
 

--- a/tests/unit/components/Map/MapUpdateIdOfCenterSpot.spec.ts
+++ b/tests/unit/components/Map/MapUpdateIdOfCenterSpot.spec.ts
@@ -3,7 +3,7 @@ import map from '@/components/Map/index.vue';
 import { MapViewState, Spot, Coordinate } from '@/store/types';
 import { shallowMount } from '@vue/test-utils';
 import { cloneDeep } from 'lodash';
-import { testMapViewState } from '../resources/testMapViewState';
+import { testMapViewState } from '../../../resources/testMapViewState';
 import { GeolocationWrapper } from '@/components/Map/GeolocationWrapper';
 
 const mapViewStateTestData: MapViewState = cloneDeep(testMapViewState);

--- a/tests/unit/components/Map/mapDisplayPolygons.spec.ts
+++ b/tests/unit/components/Map/mapDisplayPolygons.spec.ts
@@ -54,9 +54,14 @@ describe('mapコンポーネントのポリゴン表示', () => {
         // テスト用データをstoreにセット
         mapViewMutations.setMapViewState(mapViewStateTestData);
         GeolocationWrapper.watchPosition = jest.fn();
+        const initMapDisplay = jest.fn();
         wrapper = shallowMount( map, {
             attachToDocument: true,
+            methods: {
+                initMapDisplay,
+            },
         });
+        wrapper.vm.initMapDisplay = jest.fn();
     });
 
     it('storeのgetter(getSpotsForMap)で取得したspotのshape情報をgeoJson形式に変換する', () => {

--- a/tests/unit/components/Map/mapDisplayPolygons.spec.ts
+++ b/tests/unit/components/Map/mapDisplayPolygons.spec.ts
@@ -61,7 +61,6 @@ describe('mapコンポーネントのポリゴン表示', () => {
                 initMapDisplay,
             },
         });
-        wrapper.vm.initMapDisplay = jest.fn();
     });
 
     it('storeのgetter(getSpotsForMap)で取得したspotのshape情報をgeoJson形式に変換する', () => {

--- a/tests/unit/components/Map/mapDisplayRouteLine.spec.ts
+++ b/tests/unit/components/Map/mapDisplayRouteLine.spec.ts
@@ -10,9 +10,14 @@ describe('mapコンポーネントの経路表示', () => {
     let wrapper: any;
     beforeEach(() => {
         GeolocationWrapper.watchPosition = jest.fn();
+        const initMapDisplay = jest.fn();
         wrapper = shallowMount( map, {
             attachToDocument: true,
+            methods: {
+                initMapDisplay,
+            },
         });
+        wrapper.vm.initMapDisplay = jest.fn();
     });
 
     // expectで直接比較を行うと'_leaflet_id'が異なりテストが落ちるのでそれぞれの'_latLngs'と'_options'を比較するものに変更

--- a/tests/unit/components/Map/mapDisplayRouteLine.spec.ts
+++ b/tests/unit/components/Map/mapDisplayRouteLine.spec.ts
@@ -17,7 +17,6 @@ describe('mapコンポーネントの経路表示', () => {
                 initMapDisplay,
             },
         });
-        wrapper.vm.initMapDisplay = jest.fn();
     });
 
     // expectで直接比較を行うと'_leaflet_id'が異なりテストが落ちるのでそれぞれの'_latLngs'と'_options'を比較するものに変更

--- a/tests/unit/components/Map/mapSwitchMarkers.spec.ts
+++ b/tests/unit/components/Map/mapSwitchMarkers.spec.ts
@@ -43,7 +43,6 @@ describe('components/Map.vue マーカー切り替えのテスト', () => {
                 initMapDisplay,
             },
         });
-        wrapper.vm.addMarkersToMap = jest.fn();
     });
 
     afterEach(() => {

--- a/tests/unit/components/Map/mapSwitchMarkers.spec.ts
+++ b/tests/unit/components/Map/mapSwitchMarkers.spec.ts
@@ -36,8 +36,12 @@ describe('components/Map.vue マーカー切り替えのテスト', () => {
     beforeEach(() => {
         mapViewMutations.setMapViewState(mapViewStoreTestData);
         GeolocationWrapper.watchPosition = jest.fn();
+        const initMapDisplay = jest.fn();
         wrapper = shallowMount(Map, {
             attachToDocument: true,
+            methods: {
+                initMapDisplay,
+            },
         });
         wrapper.vm.addMarkersToMap = jest.fn();
     });

--- a/tests/unit/components/Map/mapUpdateDisplayLevel.spec.ts
+++ b/tests/unit/components/Map/mapUpdateDisplayLevel.spec.ts
@@ -35,7 +35,6 @@ describe('components/Map.vue zoomlevel切り替えのテスト', () => {
                 initMapDisplay,
             },
         });
-        wrapper.vm.initMapDisplay = jest.fn();
     });
 
     afterEach(() => {

--- a/tests/unit/components/Map/mapUpdateDisplayLevel.spec.ts
+++ b/tests/unit/components/Map/mapUpdateDisplayLevel.spec.ts
@@ -28,9 +28,14 @@ describe('components/Map.vue zoomlevel切り替えのテスト', () => {
     beforeEach(() => {
         mapViewMutations.setMapViewState(mapViewStoreTestData);
         GeolocationWrapper.watchPosition = jest.fn();
+        const initMapDisplay = jest.fn();
         wrapper = shallowMount(Map, {
             attachToDocument: true,
+            methods: {
+                initMapDisplay,
+            },
         });
+        wrapper.vm.initMapDisplay = jest.fn();
     });
 
     afterEach(() => {


### PR DESCRIPTION
## 実装の概要
- nextTick()を使ってテストでのエラー回避してた部分を関数に分離,nextTick削除
- テスト側で初期化の関数をモック
- 初期描画の部分ではrouteLinesの描画は削除しました

close #135 
