### PR TITLE
SpotListコンポーネントの雛形作成

### DIFF
--- a/src/components/MapView/index.vue
+++ b/src/components/MapView/index.vue
@@ -6,7 +6,8 @@
           <v-row>
             <v-col
               cols="12"
-              sm="5"
+              sm="4"
+              md="3"
               class="pa-0"
             >
               <SpotSearch/>

--- a/src/components/MapView/index.vue
+++ b/src/components/MapView/index.vue
@@ -2,11 +2,12 @@
     <div id="map-view">
       <v-app>
         <Map/>
-        <v-container id="map-container">
+        <v-container id="map-container" class="pt-0" >
           <v-row>
             <v-col
               cols="12"
               sm="5"
+              class="pl-0 pr-0 pt-0"
             >
               <SpotSearch/>
             </v-col>

--- a/src/components/MapView/index.vue
+++ b/src/components/MapView/index.vue
@@ -2,7 +2,16 @@
     <div id="map-view">
       <v-app>
         <Map/>
-        <SpotSearch/>
+        <v-container id="map-container">
+          <v-row>
+            <v-col
+              cols="12"
+              sm="5"
+            >
+              <SpotSearch/>
+            </v-col>
+          </v-row>
+        </v-container>
         <div class="wrap">
           <div id="floor-switich-button">
             <FloorSwitchButton/>
@@ -11,8 +20,6 @@
             <SpotInfo/>
           </div>
         </div>
-        <!-- <SearchBox/> -->
-        <!-- <SpotItem spotName="hoge" distance="1000 m"/> -->
       </v-app>
     </div>
 </template>
@@ -23,8 +30,6 @@ import Map from '@/components/Map/index.vue';
 import SpotInfo from '@/components/SpotInfoCard/index.vue';
 import FloorSwitchButton from '@/components/FloorSwitchButton/index.vue';
 import SpotSearch from '@/components/SpotSearch/index.vue';
-// import SearchBox from '@/components/SearchBox/index.vue';
-// import SpotItem from '@/components/SpotItem/index.vue';
 
 @Component({
     components: {
@@ -32,8 +37,6 @@ import SpotSearch from '@/components/SpotSearch/index.vue';
         SpotInfo,
         FloorSwitchButton,
         SpotSearch,
-        // SearchBox,
-        // SpotItem,
     },
 })
 export default class MapView extends Vue {
@@ -47,6 +50,13 @@ body,
 #map-view {
   position: relative;
   height: 100%;
+}
+
+#map-container {
+  position: absolute;
+  left: 0;
+  top: 0;
+  z-index: 1000;
 }
 
 .wrap {

--- a/src/components/MapView/index.vue
+++ b/src/components/MapView/index.vue
@@ -7,7 +7,7 @@
             <v-col
               cols="12"
               sm="5"
-              class="pl-0 pr-0 pt-0"
+              class="pa-0"
             >
               <SpotSearch/>
             </v-col>

--- a/src/components/SearchBox/index.vue
+++ b/src/components/SearchBox/index.vue
@@ -1,34 +1,35 @@
 <template>
     <div id="search-box">
         <v-form @submit.prevent>
-                <v-text-field
-                    v-model='searchWord'
-                    placeholder="ここで検索できます"
-                    clearable
-                    solo
-                    full-width
-                    @focus="focus"
-                    @blur="cancel"
+            <v-text-field
+                v-model='searchWord'
+                placeholder="ここで検索できます"
+                clearable
+                solo
+                full-width
+                hide-details
+                @focus="focus"
+                @blur="cancel"
+            >
+                <template
+                    v-slot:prepend-inner
                 >
-                    <template
-                        v-slot:prepend-inner
+                    <v-btn
+                        text
+                        icon
+                        v-show="!onFocus"
                     >
-                        <v-btn
-                            text
-                            icon
-                            v-show="!onFocus"
-                        >
-                            <v-icon>place</v-icon>
-                        </v-btn>
-                        <v-btn
-                            text
-                            icon
-                            v-show="onFocus"
-                        >
-                            <v-icon>keyboard_arrow_left</v-icon>
-                        </v-btn>
-                    </template>
-                </v-text-field>
+                        <v-icon>place</v-icon>
+                    </v-btn>
+                    <v-btn
+                        text
+                        icon
+                        v-show="onFocus"
+                    >
+                        <v-icon>keyboard_arrow_left</v-icon>
+                    </v-btn>
+                </template>
+            </v-text-field>
         </v-form>
     </div>
 </template>

--- a/src/components/SearchBox/index.vue
+++ b/src/components/SearchBox/index.vue
@@ -1,7 +1,6 @@
 <template>
     <div id="search-box">
         <v-form @submit.prevent>
-            <v-container>
                 <v-text-field
                     v-model='searchWord'
                     placeholder="ここで検索できます"
@@ -30,7 +29,6 @@
                         </v-btn>
                     </template>
                 </v-text-field>
-            </v-container>
         </v-form>
     </div>
 </template>
@@ -40,12 +38,4 @@
 
 <!-- Add "scoped" attribute to limit CSS to this component only -->
 <style scoped>
-#search-box {
-    position:absolute;
-    left: 10px;
-    top: 10px;
-    z-index: 1000;
-    /* background-color: white; */
-}
-
 </style>

--- a/src/components/SearchBox/index.vue
+++ b/src/components/SearchBox/index.vue
@@ -1,36 +1,44 @@
 <template>
     <div id="search-box">
-        <v-form @submit.prevent>
-            <v-text-field
-                v-model='searchWord'
-                placeholder="ここで検索できます"
-                clearable
-                solo
-                full-width
-                hide-details
-                @focus="focus"
-                @blur="cancel"
-            >
-                <template
-                    v-slot:prepend-inner
+        <v-card
+            tile
+            flat
+            color="transparent"
+        >
+            <v-form @submit.prevent>
+                <v-text-field
+                    v-model='searchWord'
+                    placeholder="ここで検索できます"
+                    clearable
+                    solo
+                    full-width
+                    hide-details
+                    @focus="focus"
+                    @blur="cancel"
+                    height="8vh"
+                    class="pa-2"
                 >
-                    <v-btn
-                        text
-                        icon
-                        v-show="!onFocus"
+                    <template
+                        v-slot:prepend-inner
                     >
-                        <v-icon>place</v-icon>
-                    </v-btn>
-                    <v-btn
-                        text
-                        icon
-                        v-show="onFocus"
-                    >
-                        <v-icon>keyboard_arrow_left</v-icon>
-                    </v-btn>
-                </template>
-            </v-text-field>
-        </v-form>
+                        <v-btn
+                            text
+                            icon
+                            v-show="!onFocus"
+                        >
+                            <v-icon>place</v-icon>
+                        </v-btn>
+                        <v-btn
+                            text
+                            icon
+                            v-show="onFocus"
+                        >
+                            <v-icon>keyboard_arrow_left</v-icon>
+                        </v-btn>
+                    </template>
+                </v-text-field>
+            </v-form>
+        </v-card>
     </div>
 </template>
 

--- a/src/components/SpotItem/index.vue
+++ b/src/components/SpotItem/index.vue
@@ -1,7 +1,15 @@
 <template>
 	<div id="spot-item">
-        {{ spotName }}
-        {{ distance }}
+        <v-card
+            tile
+        >
+            <v-list-item two-line>
+                <v-list-item-content>
+                    <v-list-item-title class="headline">{{ spotName }}</v-list-item-title>
+                    <v-list-item-subtitle>{{ distance }}</v-list-item-subtitle>
+                </v-list-item-content>
+            </v-list-item>
+        </v-card>
 	</div>
 </template>
 
@@ -10,10 +18,4 @@
 
 <!-- Add "scoped" attribute to limit CSS to this component only -->
 <style scoped>
-#spot-item {
-    position: absolute;
-    left: 10px;
-    bottom: 10px;
-    z-index: 1000;
-}
 </style>

--- a/src/components/SpotList/index.ts
+++ b/src/components/SpotList/index.ts
@@ -1,0 +1,13 @@
+import { Component, Prop, Vue, Watch } from 'vue-property-decorator';
+import { mapViewGetters, mapViewMutations } from '@/store';
+import SpotItem from '@/components/SpotItem/index.vue';
+import { Spot } from '@/store/types';
+
+@Component({
+    components: {
+        SpotItem,
+    },
+})
+export default class SpotList extends Vue {
+    @Prop() public spotSearchResults!: Spot[];
+}

--- a/src/components/SpotList/index.vue
+++ b/src/components/SpotList/index.vue
@@ -1,12 +1,17 @@
 <template>
 	<div id="spot-list">
-        <SpotItem
-            v-for="spotSearchResult in spotSearchResults"
-            v-bind:key="spotSearchResult.id + spotSearchResult.name"
-            :spotId="spotSearchResult.id"
-            :spotName="spotSearchResult.name"
-            :distance="'1000km'">
-        </SpotItem>
+        <v-list
+            class="overflow-y-auto"
+        >
+            <SpotItem
+                v-for="spotSearchResult in spotSearchResults"
+                v-bind:key="spotSearchResult.id + spotSearchResult.name"
+                :spotId="spotSearchResult.id"
+                :spotName="spotSearchResult.name"
+                :distance="'1000km'"
+            >
+            </SpotItem>
+        </v-list>
 	</div>
 </template>
 
@@ -15,4 +20,8 @@
 
 <!-- Add "scoped" attribute to limit CSS to this component only -->
 <style scoped>
+.v-list {
+    /* SearchBoxのサイズと, ボトムの余白サイズを引いたものがSearchListのサイズになる */
+    max-height: calc(100vh - (8vh + 16px) - 8px);
+}
 </style>

--- a/src/components/SpotList/index.vue
+++ b/src/components/SpotList/index.vue
@@ -1,6 +1,6 @@
 <template>
 	<div id="spot-list">
-        <SpotItem 
+        <SpotItem
             v-for="spotSearchResult in spotSearchResults"
             v-bind:key="spotSearchResult.id"
             :spotId="spotSearchResult.id"

--- a/src/components/SpotList/index.vue
+++ b/src/components/SpotList/index.vue
@@ -2,9 +2,10 @@
 	<div id="spot-list">
         <SpotItem
             v-for="spotSearchResult in spotSearchResults"
-            v-bind:key="spotSearchResult.id"
+            v-bind:key="spotSearchResult.id + spotSearchResult.name"
             :spotId="spotSearchResult.id"
-            :spotName="spotSearchResult.name">
+            :spotName="spotSearchResult.name"
+            :distance="'1000km'">
         </SpotItem>
 	</div>
 </template>
@@ -14,10 +15,4 @@
 
 <!-- Add "scoped" attribute to limit CSS to this component only -->
 <style scoped>
-#spot-list{
-    position: absolute;
-    left: 10px;
-    bottom: 10px;
-    z-index: 1000;
-}
 </style>

--- a/src/components/SpotList/index.vue
+++ b/src/components/SpotList/index.vue
@@ -1,0 +1,23 @@
+<template>
+	<div id="spot-list">
+        <SpotItem 
+            v-for="spotSearchResult in spotSearchResults"
+            v-bind:key="spotSearchResult.id"
+            :spotId="spotSearchResult.id"
+            :spotName="spotSearchResult.name">
+        </SpotItem>
+	</div>
+</template>
+
+<script lang="ts" src='./index.ts'>
+</script>
+
+<!-- Add "scoped" attribute to limit CSS to this component only -->
+<style scoped>
+#spot-list{
+    position: absolute;
+    left: 10px;
+    bottom: 10px;
+    z-index: 1000;
+}
+</style>

--- a/src/components/SpotSearch/index.ts
+++ b/src/components/SpotSearch/index.ts
@@ -2,15 +2,16 @@ import { Component, Vue, Watch } from 'vue-property-decorator';
 import { Map, Spot } from '@/store/types';
 import { mapViewGetters, mapViewMutations } from '@/store';
 import Search from '@/utils/Search';
+import SearchBox from '@/components/SearchBox/index.vue';
+import SpotList from '@/components/SpotList/index.vue';
 
 // こうなる予定？
-// @Component({
-    // components: {
-    //     SearchBox,
-    //     SpotList,
-    // }
-// })
-@Component
+@Component({
+    components: {
+        SearchBox,
+        SpotList,
+    },
+})
 export default class SpotSearch extends Vue {
     private searchWord: string = '';
     private spotListIsVisible: boolean = false;

--- a/src/components/SpotSearch/index.ts
+++ b/src/components/SpotSearch/index.ts
@@ -5,7 +5,6 @@ import Search from '@/utils/Search';
 import SearchBox from '@/components/SearchBox/index.vue';
 import SpotList from '@/components/SpotList/index.vue';
 
-// こうなる予定？
 @Component({
     components: {
         SearchBox,

--- a/src/components/SpotSearch/index.vue
+++ b/src/components/SpotSearch/index.vue
@@ -11,10 +11,4 @@
 
 <!-- Add "scoped" attribute to limit CSS to this component only -->
 <style scoped>
-/* #spot-search{
-    position:absolute;
-    left: 10px;
-    top: 10px;
-    z-index: 1000;
-} */
 </style>

--- a/src/components/SpotSearch/index.vue
+++ b/src/components/SpotSearch/index.vue
@@ -1,7 +1,9 @@
 <template>
     <div id="spot-search">
-        <SearchBox/>
-        <SpotList :spotSearchResults="spotSearchResults"></SpotList>
+        <v-card tile>
+            <SearchBox class="pa-2"/>
+            <SpotList :spotSearchResults="spotSearchResults"></SpotList>
+        </v-card>
         <!-- PropでSpotListにデータを渡す -->
     </div>
 </template>

--- a/src/components/SpotSearch/index.vue
+++ b/src/components/SpotSearch/index.vue
@@ -1,8 +1,16 @@
 <template>
     <div id="spot-search">
-        <v-card tile>
-            <SearchBox class="pa-2"/>
-            <SpotList :spotSearchResults="spotSearchResults"></SpotList>
+        <v-card
+            tile
+            flat
+            color="primary"
+        >
+            <SearchBox/>
+            <SpotList
+                :spotSearchResults="spotSearchResults"
+                v-show="true"
+                class="px-2 pb-2"
+            ></SpotList>
         </v-card>
         <!-- PropでSpotListにデータを渡す -->
     </div>

--- a/src/components/SpotSearch/index.vue
+++ b/src/components/SpotSearch/index.vue
@@ -1,7 +1,7 @@
 <template>
     <div id="spot-search">
-        <!-- <SearchBox/>
-        <SearchList/> -->
+        <SearchBox/>
+        <SpotList :spotSearchResults="spotSearchResults"></SpotList>
         <!-- PropでSpotListにデータを渡す -->
     </div>
 </template>
@@ -11,4 +11,10 @@
 
 <!-- Add "scoped" attribute to limit CSS to this component only -->
 <style scoped>
+/* #spot-search{
+    position:absolute;
+    left: 10px;
+    top: 10px;
+    z-index: 1000;
+} */
 </style>

--- a/src/components/SpotSearch/index.vue
+++ b/src/components/SpotSearch/index.vue
@@ -8,7 +8,7 @@
             <SearchBox/>
             <SpotList
                 :spotSearchResults="spotSearchResults"
-                v-show="true"
+                v-show="spotListIsVisible"
                 class="px-2 pb-2"
             ></SpotList>
         </v-card>


### PR DESCRIPTION
## 実装の概要
- SpotSearchの検索結果を表示するリストの作成
  - 余白がわかりやすいようにとりあえず青色にしています。
  - 検索結果が画面に収まらない場合、スクロール可能になります。
  - distanceの計算は行っていません。
- 画面のサイズによってSpotSearchコンポーネントのサイズが変化するように修正。
  - 横のサイズは問題ないですが、縦のサイズに関しては完全ではありません...別イシューで対応したいと思います。

<img width="1016" alt="スクリーンショット 0002-01-07 午後3 17 06" src="https://user-images.githubusercontent.com/37099863/71873483-a3082f00-3162-11ea-822f-96b1587e0d8f.png">
<img width="1015" alt="スクリーンショット 0002-01-07 午後3 16 24" src="https://user-images.githubusercontent.com/37099863/71873486-a6031f80-3162-11ea-8e3f-f00b5c6a349c.png">


close #160 
