### PR TITLE
検索窓をクリック/解除するとspotListIsVisibleの値を更新する

### DIFF
--- a/src/components/SearchBox/index.ts
+++ b/src/components/SearchBox/index.ts
@@ -11,13 +11,14 @@ export default class SearchBox extends Vue {
      */
     private focus(): void {
         this.onFocus = true;
-        this.openSpotList();
+        // SpotListを表示するように伝える
+        this.$emit('toggleSpotList', true);
     }
 
     /**
      * text-field以外をクリックした時にonFocusをfalseにする
      */
-    private focusCancel(): void {
+    private unfocus(): void {
         this.onFocus = false;
     }
 
@@ -26,27 +27,10 @@ export default class SearchBox extends Vue {
      * spotListを閉じるように伝える
      */
     private exitSpotSearch(): void {
-        this.closeSpotList();
+        // SpotListを非表示するように伝える
+        this.$emit('toggleSpotList', false);
         this.onFocus = false;
         // text-fieldからフォーカスを外す
         (this.$refs.searchTextField as HTMLInputElement).blur();
-    }
-
-    /**
-     * spotListを表示するよう伝える
-     * @Emit 'toggleSpotList' true
-     */
-    @Emit('toggleSpotList')
-    private openSpotList(): boolean {
-        return true;
-    }
-
-    /**
-     * spotListを非表示にするよう伝える
-     * @Emit 'toggleSpotList' false
-     */
-    @Emit('toggleSpotList')
-    private closeSpotList(): boolean {
-        return false;
     }
 }

--- a/src/components/SearchBox/index.ts
+++ b/src/components/SearchBox/index.ts
@@ -3,7 +3,7 @@ import { mdiAccount } from '@mdi/js';
 
 @Component
 export default class SearchBox extends Vue {
-    public searchWord: string = '';
+    private searchWord: string = '';
     private onFocus: boolean = false;
 
     /**
@@ -19,7 +19,6 @@ export default class SearchBox extends Vue {
      */
     private focusCancel(): void {
         this.onFocus = false;
-        console.log(this.$refs['search-text']);
     }
 
     /**
@@ -28,7 +27,7 @@ export default class SearchBox extends Vue {
      */
     private exitSpotSearch(): void {
         this.closeSpotList();
-        this.focusCancel();
+        this.onFocus = false;
     }
 
     /**

--- a/src/components/SearchBox/index.ts
+++ b/src/components/SearchBox/index.ts
@@ -15,7 +15,7 @@ export default class SearchBox extends Vue {
     }
 
     /**
-     * text-field以外をクリックした時にフォーカス状態を解除する
+     * text-field以外をクリックした時にonFocusをfalseにする
      */
     private focusCancel(): void {
         this.onFocus = false;
@@ -28,6 +28,8 @@ export default class SearchBox extends Vue {
     private exitSpotSearch(): void {
         this.closeSpotList();
         this.onFocus = false;
+        // text-fieldからフォーカスを外す
+        (this.$refs.searchTextField as HTMLInputElement).blur();
     }
 
     /**

--- a/src/components/SearchBox/index.ts
+++ b/src/components/SearchBox/index.ts
@@ -19,13 +19,14 @@ export default class SearchBox extends Vue {
      */
     private focusCancel(): void {
         this.onFocus = false;
+        console.log(this.$refs['search-text']);
     }
 
     /**
      * 戻るボタンをクリックした時にspotSearchコンポーネントに
      * spotListを閉じるように伝える
      */
-    private exitSpotSearch(): void{
+    private exitSpotSearch(): void {
         this.closeSpotList();
         this.focusCancel();
     }

--- a/src/components/SearchBox/index.ts
+++ b/src/components/SearchBox/index.ts
@@ -1,4 +1,4 @@
-import { Component, Watch, Vue } from 'vue-property-decorator';
+import { Component, Watch, Vue, Emit } from 'vue-property-decorator';
 import { mdiAccount } from '@mdi/js';
 
 @Component
@@ -6,10 +6,45 @@ export default class SearchBox extends Vue {
     public searchWord: string = '';
     private onFocus: boolean = false;
 
+    /**
+     * text-fieldをクリックした時にフォーカス状態にする
+     */
     private focus(): void {
         this.onFocus = true;
+        this.openSpotList();
     }
-    private cancel(): void {
+
+    /**
+     * text-field以外をクリックした時にフォーカス状態を解除する
+     */
+    private focusCancel(): void {
         this.onFocus = false;
+    }
+
+    /**
+     * 戻るボタンをクリックした時にspotSearchコンポーネントに
+     * spotListを閉じるように伝える
+     */
+    private exitSpotSearch(): void{
+        this.closeSpotList();
+        this.focusCancel();
+    }
+
+    /**
+     * spotListを表示するよう伝える
+     * @Emit 'toggleSpotList' true
+     */
+    @Emit('toggleSpotList')
+    private openSpotList(): boolean {
+        return true;
+    }
+
+    /**
+     * spotListを非表示にするよう伝える
+     * @Emit 'toggleSpotList' false
+     */
+    @Emit('toggleSpotList')
+    private closeSpotList(): boolean {
+        return false;
     }
 }

--- a/src/components/SearchBox/index.vue
+++ b/src/components/SearchBox/index.vue
@@ -9,6 +9,7 @@
                     solo
                     full-width
                     @focus="focus"
+                    @click="focus"
                     @blur="focusCancel"
                 >
                     <template

--- a/src/components/SearchBox/index.vue
+++ b/src/components/SearchBox/index.vue
@@ -10,6 +10,7 @@
                     full-width
                     @click="focus"
                     @blur="focusCancel"
+                    ref="searchTextField"
                 >
                     <template
                         v-slot:prepend-inner

--- a/src/components/SearchBox/index.vue
+++ b/src/components/SearchBox/index.vue
@@ -8,7 +8,6 @@
                     clearable
                     solo
                     full-width
-                    @focus="focus"
                     @click="focus"
                     @blur="focusCancel"
                 >
@@ -16,6 +15,7 @@
                         v-slot:prepend-inner
                     >
                         <v-btn
+                            id="place"
                             text
                             icon
                             v-show="!onFocus"
@@ -23,10 +23,11 @@
                             <v-icon>place</v-icon>
                         </v-btn>
                         <v-btn
+                            id="arrow"
                             text
                             icon
                             v-show="onFocus"
-                            v-on:click="exitSpotSearch"
+                            @click="exitSpotSearch"
                         >
                             <v-icon>keyboard_arrow_left</v-icon>
                         </v-btn>

--- a/src/components/SearchBox/index.vue
+++ b/src/components/SearchBox/index.vue
@@ -9,7 +9,7 @@
                     solo
                     full-width
                     @click="focus"
-                    @blur="focusCancel"
+                    @blur="unfocus"
                     ref="searchTextField"
                 >
                     <template

--- a/src/components/SearchBox/index.vue
+++ b/src/components/SearchBox/index.vue
@@ -9,7 +9,7 @@
                     solo
                     full-width
                     @focus="focus"
-                    @blur="cancel"
+                    @blur="focusCancel"
                 >
                     <template
                         v-slot:prepend-inner
@@ -25,6 +25,7 @@
                             text
                             icon
                             v-show="onFocus"
+                            v-on:click="exitSpotSearch"
                         >
                             <v-icon>keyboard_arrow_left</v-icon>
                         </v-btn>

--- a/src/components/SpotSearch/index.ts
+++ b/src/components/SpotSearch/index.ts
@@ -2,15 +2,16 @@ import { Component, Vue, Watch } from 'vue-property-decorator';
 import { Map, Spot } from '@/store/types';
 import { mapViewGetters, mapViewMutations } from '@/store';
 import Search from '@/utils/Search';
+import SearchBox from '@/components/SearchBox/index.vue';
 
 // こうなる予定？
-// @Component({
-    // components: {
-    //     SearchBox,
-    //     SpotList,
-    // }
-// })
-@Component
+@Component({
+    components: {
+        SearchBox,
+        // SpotList,
+    },
+})
+
 export default class SpotSearch extends Vue {
     private searchWord: string = '';
     private spotListIsVisible: boolean = false;

--- a/src/components/SpotSearch/index.vue
+++ b/src/components/SpotSearch/index.vue
@@ -1,8 +1,9 @@
 <template>
     <div id="spot-search">
-        <!-- <SearchBox/>
-        <SearchList/> -->
+        <SearchBox @toggleSpotList="setSpotListIsVisible"/>
+        <!-- <SearchList/> -->
         <!-- PropでSpotListにデータを渡す -->
+        <div v-show="spotListIsVisible">nanka</div>
     </div>
 </template>
 

--- a/src/components/SpotSearch/index.vue
+++ b/src/components/SpotSearch/index.vue
@@ -3,7 +3,6 @@
         <SearchBox @toggleSpotList="setSpotListIsVisible"/>
         <!-- <SearchList/> -->
         <!-- PropでSpotListにデータを渡す -->
-        <div v-show="spotListIsVisible">nanka</div>
     </div>
 </template>
 

--- a/tests/unit/components/SearchBox/searchBox.spec.ts
+++ b/tests/unit/components/SearchBox/searchBox.spec.ts
@@ -1,0 +1,49 @@
+import { createLocalVue, mount } from '@vue/test-utils';
+import SearchBox from '@/components/SearchBox/index.vue';
+import Vuetify from 'vuetify';
+
+describe('SearchBoxコンポーネントのテスト', () => {
+    let wrapper: any;
+    let localVue: any;
+    let vuetify: any;
+
+    beforeEach(() => {
+        vuetify = new Vuetify();
+        localVue = createLocalVue();
+        localVue.use(Vuetify);
+        wrapper = mount(SearchBox, {
+            localVue,
+            vuetify,
+            attachToDocument: true,
+        });
+    });
+
+    afterEach(() => {
+        // Map components already initialized防止
+        wrapper.destroy();
+    });
+
+    it('text-fieldをクリックするとフォーカス状態になり，emitする', () => {
+        // text-fieldのclickイベント発火
+        const textField = wrapper.find('input');
+        textField.trigger('click');
+        // emitした時，イベントはtoggleSpotList
+        expect(wrapper.emitted().toggleSpotList).toBeTruthy();
+        // イベントの数は一回
+        expect(wrapper.emitted().toggleSpotList.length).toBe(1);
+        // emitのpayloadはtrue
+        expect(wrapper.emitted().toggleSpotList[0]).toStrictEqual([true]);
+    });
+
+    it('戻るボタンをクリックした時，フォーカス解除してemitする', () => {
+        // 戻るボタンのclickイベント発火
+        const btn = wrapper.find('.v-btn#arrow');
+        btn.trigger('click');
+        // emitした時，イベントはtoggleSpotList
+        expect(wrapper.emitted().toggleSpotList).toBeTruthy();
+        // イベントの数は一回
+        expect(wrapper.emitted().toggleSpotList.length).toBe(1);
+        // emitのpayloadはfalse
+        expect(wrapper.emitted().toggleSpotList[0]).toStrictEqual([false]);
+    });
+});

--- a/tests/unit/components/SpotSearch/spotSearch.spec.ts
+++ b/tests/unit/components/SpotSearch/spotSearch.spec.ts
@@ -1,0 +1,23 @@
+import { shallowMount } from '@vue/test-utils';
+import SpotSearch from '@/components/SpotSearch/index.vue';
+
+describe('SpotSearchコンポーネントのテスト', () => {
+    let wrapper: any;
+
+    beforeEach(() => {
+        wrapper = shallowMount(SpotSearch, {
+            attachToDocument: true,
+        });
+    });
+
+    afterEach(() => {
+        // Map components already initialized防止
+        wrapper.destroy();
+    });
+
+    it('toggleSpotListイベントが発火するとsetSpotListIsVisibleが呼ばれる', () => {
+        // イベント発火
+
+        // 関数呼び出し確認
+    });
+});

--- a/tests/unit/components/SpotSearch/spotSearch.spec.ts
+++ b/tests/unit/components/SpotSearch/spotSearch.spec.ts
@@ -1,5 +1,6 @@
 import { shallowMount } from '@vue/test-utils';
 import SpotSearch from '@/components/SpotSearch/index.vue';
+import SearchBox from '@/components/SearchBox/index.vue';
 
 describe('SpotSearchコンポーネントのテスト', () => {
     let wrapper: any;
@@ -11,13 +12,16 @@ describe('SpotSearchコンポーネントのテスト', () => {
     });
 
     afterEach(() => {
-        // Map components already initialized防止
         wrapper.destroy();
     });
 
     it('toggleSpotListイベントが発火するとsetSpotListIsVisibleが呼ばれる', () => {
-        // イベント発火
-
-        // 関数呼び出し確認
+        // これは単体テストなのか...?
+        // 初期値はfalse
+        expect(wrapper.vm.spotListIsVisible).toBe(false);
+        // 子コンポーネントからのemit
+        wrapper.find(SearchBox).vm.$emit('toggleSpotList', true);
+        // trueに変わっていることを確認
+        expect(wrapper.vm.spotListIsVisible).toBe(true);
     });
 });


### PR DESCRIPTION
## 実装の概要
### SearchBox側
- SearchBoxを触った時にSpotListを表示する
  - text-fieldをクリックした時にtoggleSpotListイベントをemitする
- 戻るボタンを押した時にSpotListを非表示にする
  - クリック次にtoggleSpotListイベントをemitする
### SpotSearch側
- toggleSpotListイベントでsetSpotListIsVisibleを呼び出す機能追加

## テストに関して
- SpotSearchのテストですが，子コンポーネントのemitを確認するテストを書いています．
- SearchBox, SpotSearhの2つのコンポーネントを使用してテストしているため，単体テストからは移す方がいいかもしれないです

close #153 
