### PR TITLE
検索結果でspotItemの距離を計算する処理を追加

### DIFF
--- a/src/components/SpotList/index.ts
+++ b/src/components/SpotList/index.ts
@@ -18,13 +18,13 @@ export default class SpotList extends Vue {
     private currentPosition?: Coordinate;
 
     public mounted() {
+        // 現在地を取得する
         this.currentPositionHandler = GeolocationWrapper.watchPosition(
             (pos: Position) => {
                 this.currentPosition = {
                     lat: pos.coords.latitude,
                     lng: pos.coords.longitude,
                 };
-                console.log(this.currentPosition);
             },
             (err: PositionError) => {
                 throw err;
@@ -37,17 +37,29 @@ export default class SpotList extends Vue {
         );
     }
 
+    /**
+     * 現在地を取得できている場合、現在地とスポットの距離を計算し、文字列型にformatして返す
+     * 現在地を取得できていない場合、空文字列を返す
+     * @param spot 現在地との距離を計算したいスポット
+     */
     private calculateDistanceFromCurrentPosition(spot: Spot): string {
         if (this.currentPosition === undefined) {
             return '';
         }
         const distance = getDistance(spot.coordinate, this.currentPosition);
-        // return this.formatDistance(distance);
-        return distance.toString();
+        return this.formatDistance(distance);
     }
 
-    private formatDistance(distanceInMeter: number): string {
-        // m km表記で返す
-        return '';
+    /**
+     * 数値の距離を値によって、mまたはkm付きの文字列に変換する
+     * @param distanceInMeters 変換したい距離(m)
+     */
+    private formatDistance(distanceInMeters: number): string {
+        if (distanceInMeters < 1000) {
+            return distanceInMeters.toString() + 'm';
+        } else {
+            const distanceInKMeters = Math.round(distanceInMeters / 100) / 10;
+            return distanceInKMeters.toString() + 'km';
+        }
     }
 }

--- a/src/components/SpotList/index.ts
+++ b/src/components/SpotList/index.ts
@@ -1,7 +1,10 @@
 import { Component, Prop, Vue, Watch } from 'vue-property-decorator';
 import { mapViewGetters, mapViewMutations } from '@/store';
 import SpotItem from '@/components/SpotItem/index.vue';
-import { Spot } from '@/store/types';
+import { Spot, Coordinate } from '@/store/types';
+import { GeolocationWrapper } from '@/components/Map/GeolocationWrapper';
+import { LatLngExpression } from 'leaflet';
+import { getDistance } from 'geolib';
 
 @Component({
     components: {
@@ -10,4 +13,41 @@ import { Spot } from '@/store/types';
 })
 export default class SpotList extends Vue {
     @Prop() public spotSearchResults!: Spot[];
+
+    private currentPositionHandler?: number;
+    private currentPosition?: Coordinate;
+
+    public mounted() {
+        this.currentPositionHandler = GeolocationWrapper.watchPosition(
+            (pos: Position) => {
+                this.currentPosition = {
+                    lat: pos.coords.latitude,
+                    lng: pos.coords.longitude,
+                };
+                console.log(this.currentPosition);
+            },
+            (err: PositionError) => {
+                throw err;
+            },
+            {
+                enableHighAccuracy: true,
+                timeout: 10000,
+                maximumAge: 0,
+            },
+        );
+    }
+
+    private calculateDistanceFromCurrentPosition(spot: Spot): string {
+        if (this.currentPosition === undefined) {
+            return '';
+        }
+        const distance = getDistance(spot.coordinate, this.currentPosition);
+        // return this.formatDistance(distance);
+        return distance.toString();
+    }
+
+    private formatDistance(distanceInMeter: number): string {
+        // m km表記で返す
+        return '';
+    }
 }

--- a/src/components/SpotList/index.ts
+++ b/src/components/SpotList/index.ts
@@ -41,6 +41,8 @@ export default class SpotList extends Vue {
      * 現在地を取得できている場合、現在地とスポットの距離を計算し、文字列型にformatして返す
      * 現在地を取得できていない場合、空文字列を返す
      * @param spot 現在地との距離を計算したいスポット
+     * @return 空文字列 
+     * @return 文字列型の単位付きの距離
      */
     private calculateDistanceFromCurrentPosition(spot: Spot): string {
         if (this.currentPosition === undefined) {
@@ -53,6 +55,7 @@ export default class SpotList extends Vue {
     /**
      * 数値の距離を値によって、mまたはkm付きの文字列に変換する
      * @param distanceInMeters 変換したい距離(m)
+     * @return 文字列型の単位付きの距離
      */
     private formatDistance(distanceInMeters: number): string {
         if (distanceInMeters < 1000) {

--- a/src/components/SpotList/index.ts
+++ b/src/components/SpotList/index.ts
@@ -38,7 +38,7 @@ export default class SpotList extends Vue {
     }
 
     /**
-     * 現在地を取得できている場合、現在地とスポットの距離を計算し、文字列型にformatして返す
+     * 現在地とスポットの距離を計算し、文字列型にformatして返す
      * 現在地を取得できていない場合、空文字列を返す
      * @param spot 現在地との距離を計算したいスポット
      * @return 空文字列
@@ -53,7 +53,7 @@ export default class SpotList extends Vue {
     }
 
     /**
-     * 数値の距離を値によって、mまたはkm付きの文字列に変換する
+     * 値によって数値の距離をmまたはkm付きの文字列に変換する
      * @param distanceInMeters 変換したい距離(m)
      * @return 文字列型の単位付きの距離
      */

--- a/src/components/SpotList/index.ts
+++ b/src/components/SpotList/index.ts
@@ -41,7 +41,7 @@ export default class SpotList extends Vue {
      * 現在地を取得できている場合、現在地とスポットの距離を計算し、文字列型にformatして返す
      * 現在地を取得できていない場合、空文字列を返す
      * @param spot 現在地との距離を計算したいスポット
-     * @return 空文字列 
+     * @return 空文字列
      * @return 文字列型の単位付きの距離
      */
     private calculateDistanceFromCurrentPosition(spot: Spot): string {
@@ -61,6 +61,7 @@ export default class SpotList extends Vue {
         if (distanceInMeters < 1000) {
             return distanceInMeters.toString() + 'm';
         } else {
+            // km表示に変換した時の小数点第一位以下を丸める
             const distanceInKMeters = Math.round(distanceInMeters / 100) / 10;
             return distanceInKMeters.toString() + 'km';
         }

--- a/src/components/SpotList/index.vue
+++ b/src/components/SpotList/index.vue
@@ -8,7 +8,7 @@
                 v-bind:key="spotSearchResult.id + spotSearchResult.name"
                 :spotId="spotSearchResult.id"
                 :spotName="spotSearchResult.name"
-                :distance="'1000km'"
+                :distance="calculateDistanceFromCurrentPosition(spotSearchResult)"
             >
             </SpotItem>
         </v-list>

--- a/tests/unit/components/SpotList/spotList.spec.ts
+++ b/tests/unit/components/SpotList/spotList.spec.ts
@@ -1,0 +1,59 @@
+import { shallowMount } from '@vue/test-utils';
+import SpotList from '@/components/SpotList/index.vue';
+import { GeolocationWrapper } from '@/components/Map/GeolocationWrapper';
+import { Spot } from '@/store/types';
+import { getDistance } from 'geolib';
+
+describe('SpotListコンポーネントのテスト', () => {
+    let wrapper: any;
+
+    beforeEach(() => {
+        GeolocationWrapper.watchPosition = jest.fn();
+        wrapper = shallowMount(SpotList, {
+            attachToDocument: true,
+        });
+    });
+
+    afterEach(() => {
+        wrapper.destroy();
+    });
+
+    const testSpot: Spot = {
+        id: 1,
+        name: 'ウエスト2号館',
+        coordinate: {
+            lat: 33.59600170923035,
+            lng: 130.21851181983948,
+        },
+        gateNodeIds: [],
+        detailMapIds: [],
+        detailMapLevelNames: [],
+        lastViewedDetailMapId: null,
+    };
+
+    it('calculateDistanceFromCurrentPositionが取得された現在地とスポット間の距離を計算してformat型に返す', () => {
+        const currentPosition = {
+            lat: 33.595502,
+            lng: 130.218238,
+        };
+        const expectedDistance = getDistance(testSpot.coordinate, currentPosition);
+        wrapper.vm.currentPosition = currentPosition;
+        wrapper.vm.formatDistance = jest.fn((distance) => {
+            expect(distance).toBe(expectedDistance);
+        });
+        wrapper.vm.calculateDistanceFromCurrentPosition(testSpot);
+    });
+
+    it('現在地を取得できなかった場合、calculateDistanceFromCurrentPositionが空文字列を返す', () => {
+        wrapper.vm.currentPosition = undefined;
+        expect(wrapper.vm.calculateDistanceFromCurrentPosition(testSpot)).toBe('');
+    });
+
+    it('formatDistanceが数値の距離を値によって、mまたはkm付きの文字列に変換する', () => {
+        // 受け取った数値が1000未満の場合、単位(m)をつけて文字列型に変換する
+        expect(wrapper.vm.formatDistance(900)).toBe('0m');
+        // 受け取った数値が1000以上の場合、小数第一位に丸め、単位(km)をつけて文字列型に変換する
+        expect(wrapper.vm.formatDistance(1000)).toBe('1km');
+        expect(wrapper.vm.formatDistance(2222)).toBe('2.2km');
+    });
+});

--- a/tests/unit/components/SpotList/spotList.spec.ts
+++ b/tests/unit/components/SpotList/spotList.spec.ts
@@ -51,7 +51,7 @@ describe('SpotListコンポーネントのテスト', () => {
 
     it('formatDistanceが数値の距離を値によって、mまたはkm付きの文字列に変換する', () => {
         // 受け取った数値が1000未満の場合、単位(m)をつけて文字列型に変換する
-        expect(wrapper.vm.formatDistance(900)).toBe('0m');
+        expect(wrapper.vm.formatDistance(900)).toBe('900m');
         // 受け取った数値が1000以上の場合、小数第一位に丸め、単位(km)をつけて文字列型に変換する
         expect(wrapper.vm.formatDistance(1000)).toBe('1km');
         expect(wrapper.vm.formatDistance(2222)).toBe('2.2km');

--- a/tests/unit/components/SpotList/spotList.spec.ts
+++ b/tests/unit/components/SpotList/spotList.spec.ts
@@ -31,7 +31,7 @@ describe('SpotListコンポーネントのテスト', () => {
         lastViewedDetailMapId: null,
     };
 
-    it('calculateDistanceFromCurrentPositionが取得された現在地とスポット間の距離を計算してformat型に返す', () => {
+    it('calculateDistanceFromCurrentPositionが取得された現在地とスポット間の距離を計算してformatした結果を返す', () => {
         const currentPosition = {
             lat: 33.595502,
             lng: 130.218238,
@@ -39,9 +39,10 @@ describe('SpotListコンポーネントのテスト', () => {
         const expectedDistance = getDistance(testSpot.coordinate, currentPosition);
         wrapper.vm.currentPosition = currentPosition;
         wrapper.vm.formatDistance = jest.fn((distance) => {
-            expect(distance).toBe(expectedDistance);
+            return distance.toString();
         });
-        wrapper.vm.calculateDistanceFromCurrentPosition(testSpot);
+        const resultDistanceInString = wrapper.vm.calculateDistanceFromCurrentPosition(testSpot);
+        expect(resultDistanceInString).toBe(expectedDistance.toString());
     });
 
     it('現在地を取得できなかった場合、calculateDistanceFromCurrentPositionが空文字列を返す', () => {


### PR DESCRIPTION
## 実装の概要
- spotList内で現在地を取得する処理を追加。
- calculateDistanceFromCurrentPositionで現在地とスポットとの距離を計算し、フォーマットしてspotItemに渡す。
  - 現在地を取得できていない場合、空文字列を返す
- formatDistanceは、1000未満の場合は、数字＋m（例：900→900m）、1000以上の場合は、十の位で四捨五入を行い数字+km（例：2222→2.2km）の文字列型にする。

close #194 
