### PR TITLE
FloorSwitchButtonの不具合（押したかどうかの見た目）修正

### DIFF
--- a/src/components/FloorSwitchButton/index.ts
+++ b/src/components/FloorSwitchButton/index.ts
@@ -38,8 +38,7 @@ export default class FloorSwitchButton extends Vue {
      * 階層ボタンを押した時にスポットのlastViewedDetailMapIdを更新する．
      * @param floorName 押された階層ボタンの階層名
      */
-    private updateLastViewedDetailMapIdOnClick(floorName: string): void {
-        const index: number = this.floorNames.findIndex((name) => name === floorName);
+    private updateLastViewedDetailMapIdOnClick(index: number): void {
         const lastViewedDetailMapId: number = this.floorMapIds[index];
         const parentMapId: number = mapViewGetters.rootMapId;
         const spotId: number | null = mapViewGetters.idOfCenterSpotInRootMap;
@@ -67,7 +66,7 @@ export default class FloorSwitchButton extends Vue {
             this.clearButtonContent();
             return;
         }
-        const spot = mapViewGetters.getSpotById({parentMapId,　spotId});
+        const spot = mapViewGetters.getSpotById({parentMapId, spotId});
         if (spot.detailMapIds.length === 0) {
             this.clearButtonContent();
             return;

--- a/src/components/FloorSwitchButton/index.ts
+++ b/src/components/FloorSwitchButton/index.ts
@@ -1,5 +1,6 @@
 import { Component, Prop, Vue, Watch } from 'vue-property-decorator';
-import { mapViewGetters, mapViewMutations } from '@/store';
+import { store, mapViewGetters, mapViewMutations } from '@/store';
+import { MapViewGetters } from '@/store/modules/MapViewModule/MapViewGetters';
 import { DisplayLevelType } from '@/store/types';
 
 @Component
@@ -12,6 +13,17 @@ export default class FloorSwitchButton extends Vue {
     // 階層ボタンの見た目に関するメンバ
     private selectedFloorButtonIndex: number | undefined = 0;
     private isVisible: boolean = false;
+
+    public mounted() {
+        store.watch(
+            (state, getters: MapViewGetters) => getters.displayLevel,
+            (value, oldValue) => this.changeButtonIsVisible(value, oldValue),
+        );
+        store.watch(
+            (state, getters: MapViewGetters) => getters.idOfCenterSpotInRootMap,
+            (value, oldValue) => this.updateContentOfFloorSwitchButton(value, oldValue),
+        );
+    }
 
     /**
      * 階層ボタンの内容を初期化する．
@@ -45,17 +57,9 @@ export default class FloorSwitchButton extends Vue {
     }
 
     /**
-     * changeButtonContentで監視するプロパティ
-     */
-    get idOfCenterSpotInRootMap(): number | null {
-        return mapViewGetters.idOfCenterSpotInRootMap;
-    }
-
-    /**
      * 画面中央の詳細マップ持ちスポットに合わせて階層切り替えボタンの内容を更新する．
      * 下の階が下に表示されるようにセットする．
      */
-    @Watch('idOfCenterSpotInRootMap')
     private updateContentOfFloorSwitchButton(newCenterSpotId: number | null, oldCenterSpotId: number | null): void {
         const parentMapId: number = mapViewGetters.rootMapId;
         const spotId: number | null = newCenterSpotId;
@@ -82,16 +86,8 @@ export default class FloorSwitchButton extends Vue {
     }
 
     /**
-     * changeButtonIsVisibleで監視するプロパティ
-     */
-    get displayLevel(): DisplayLevelType {
-        return mapViewGetters.displayLevel;
-    }
-
-    /**
      * displayLevelに合わせて階層切り替えボタンの表示/非表示を切り替える．
      */
-    @Watch('displayLevel')
     private changeButtonIsVisible(newDisplayLevel: DisplayLevelType, oldDisplayLevel: DisplayLevelType): void {
         if (newDisplayLevel === 'detail') {
             this.isVisible = true;

--- a/src/components/FloorSwitchButton/index.vue
+++ b/src/components/FloorSwitchButton/index.vue
@@ -1,5 +1,5 @@
 <template>
-	<div id="floor-switch-button" v-show="isVisible">
+    <div id="floor-switch-button" v-show="isVisible">
         <v-container class="pa-0">
             <v-row
                 no-gutters
@@ -8,20 +8,21 @@
                     <v-btn-toggle
                         tile
                         mandatory
+                        color="primary"
                         v-model="selectedFloorButtonIndex"
                     >
                         <v-btn
-                            v-for="floorName in floorNames"
-                            v-bind:key="floorName"
-                            @click="updateLastViewedDetailMapIdOnClick(floorName)"
+                            v-for="(floorName, index) in floorNames"
+                            v-bind:key="index"
+                            @click="updateLastViewedDetailMapIdOnClick(index)"
                         >
-                        {{ floorName }}
+                            {{ floorName }}
                         </v-btn>
                     </v-btn-toggle>
                 </v-col>
             </v-row>
         </v-container>
-	</div>
+    </div>
 </template>
 
 <script lang="ts" src='./index.ts'>

--- a/tests/unit/components/FloorSwitchButton/FloorSwitchButton.spec.ts
+++ b/tests/unit/components/FloorSwitchButton/FloorSwitchButton.spec.ts
@@ -38,7 +38,7 @@ describe('components/FloorSwitchButton.vue 階層ボタンのテスト', () => {
         // 中心付近にスポットが存在しない場合
         // ボタンが表示されないため実際に実行される予定はないがテスト
         mapViewMutations.setNonExistentOfCenterSpotInRootMap();
-        wrapper.vm.updateLastViewedDetailMapIdOnClick('1F');
+        wrapper.vm.updateLastViewedDetailMapIdOnClick(0);
         const actualLastViewedDetailMapIdWithNoSpot: number | null =
             mapViewGetters.getLastViewedDetailMapId({
                 parentMapId: 0,
@@ -48,8 +48,8 @@ describe('components/FloorSwitchButton.vue 階層ボタンのテスト', () => {
 
         // 中心付近に詳細マップ持ちスポットがある場合
         mapViewMutations.setIdOfCenterSpotInRootMap(0);
-        const floorName: string = '2F';
-        wrapper.vm.updateLastViewedDetailMapIdOnClick(floorName);
+        const indexOfClickedButton: number = 0;
+        wrapper.vm.updateLastViewedDetailMapIdOnClick(indexOfClickedButton);
         const expectedLastViewedDetailMapId: number = 2;
         const actualLastViewedDetailMapId: number | null =
             mapViewGetters.getLastViewedDetailMapId({


### PR DESCRIPTION
## 実装の概要
階層切り替えボタンを押した場合，その階層が選択されたままの状態（見た目）を維持していなかったので修正

close #204 
