### PR TITLE
検索単語が空文字の場合に検索を行わないように修正

### DIFF
--- a/src/utils/Search.ts
+++ b/src/utils/Search.ts
@@ -14,6 +14,9 @@ export default class Search {
      * @return keywordにかかったスポットのリスト
      */
     public searchSpots(keyword: string): Spot[] {
+        if (keyword === '') {
+            return [];
+        }
         const searchExp = new RegExp(keyword, 'i'); // 'i'オプションで大文字小文字を区別しない
         return this.targetSpots.filter((s: Spot) => {
             return s.name.match(searchExp);

--- a/tests/unit/utils/Search.spec.ts
+++ b/tests/unit/utils/Search.spec.ts
@@ -48,4 +48,13 @@ describe('Searchクラスのテスト', () => {
         expect(actualResult).toStrictEqual(expectedResult);
     });
 
+    it('検索ワードが空文字の場合，検索しない', () => {
+        const targetSpotsForSearch = spotsForTest;
+        const searchObj = new Search(targetSpotsForSearch);
+        const keyword: string = '';
+        const actualResult: Spot[] = searchObj.searchSpots(keyword);
+        const expectedResult: Spot[] = [];
+        expect(actualResult).toStrictEqual(expectedResult);
+    });
+
 });


### PR DESCRIPTION
## 実装の概要
検索ボックスが空の時に検索を行わないように修正しました．

close #211 
