### PR TITLE
SpotItemをクリックした時にSpotまで地図を移動するように

### DIFF
--- a/src/components/Map/index.ts
+++ b/src/components/Map/index.ts
@@ -1,5 +1,5 @@
 import { Component, Vue, Watch} from 'vue-property-decorator';
-import { mapViewGetters, mapViewMutations } from '@/store';
+import { mapViewGetters, mapViewMutations, store } from '@/store';
 import { SpotForMap, Coordinate, Bounds, Spot } from '@/store/types';
 import 'leaflet/dist/leaflet.css';
 import L from 'leaflet';
@@ -8,6 +8,7 @@ import { findNearest, getDistance } from 'geolib';
 import { GeolibInputCoordinates } from 'geolib/es/types';
 import CurrentLocationMarker from '@/components/Map/Marker/CurrentLocationMarker';
 import DefaultSpotMarker from '@/components/Map/Marker/DefaultSpotMarker';
+import { MapViewGetters } from '@/store/modules/MapViewModule/MapViewGetters';
 
 
 @Component
@@ -32,10 +33,7 @@ export default class Map extends Vue {
         const rootMapCenter: Coordinate = this.calculateCenter(mapViewGetters.rootMapBounds);
         this.centerLat = rootMapCenter.lat;
         this.centerLng = rootMapCenter.lng;
-        this.map = L.map('map').setView(
-            [this.centerLat, this.centerLng],
-            this.zoomLevel,
-        );
+        this.map = L.map('map').setView([this.centerLat, this.centerLng], this.zoomLevel);
         this.tileLayer = L.tileLayer(
             'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
                 maxZoom: 23,
@@ -45,6 +43,10 @@ export default class Map extends Vue {
         this.map.on('zoomend', this.updateDisplayLevel);
         this.map.on('move', this.updateIdOfCenterSpotInRootMap);
         this.map.zoomControl.setPosition('bottomright');
+        store.watch(
+            (state, getters: MapViewGetters) => mapViewGetters.mapCenterPositionToFocus,
+            (value, oldValue) => this.map.setView(value, this.zoomLevel),
+        );
         this.initMapDisplay();
     }
 

--- a/src/components/Map/index.ts
+++ b/src/components/Map/index.ts
@@ -218,6 +218,9 @@ export default class Map extends Vue {
         this.map.addLayer(routeLayer);
     }
 
+    /**
+     * マップ表示の移動のためにStoreのgetterのウォッチを行う
+     */
     private watchStoreForMoveMapCenter(): void {
         store.watch(
             (state, getters: MapViewGetters) => mapViewGetters.spotToDisplayInMapCenter,

--- a/src/components/Map/index.ts
+++ b/src/components/Map/index.ts
@@ -231,7 +231,7 @@ export default class Map extends Vue {
                 }
                 const spotToDisplayInMapCenter: Spot
                     = mapViewGetters.getSpotById({parentMapId: spot.mapId, spotId: spot.spotId});
-                this.map.setView(spotToDisplayInMapCenter.coordinate, zoomLevel);
+                this.map.flyTo(spotToDisplayInMapCenter.coordinate, zoomLevel);
             },
         );
     }

--- a/src/components/Map/index.ts
+++ b/src/components/Map/index.ts
@@ -40,7 +40,10 @@ export default class Map extends Vue {
         this.map.zoomControl.setPosition('bottomright');
         store.watch(
             (state, getters: MapViewGetters) => mapViewGetters.spotToFocus,
-            (value, oldValue) => {},
+            (spot, oldSpot) => {
+                const spotToFocus: Spot = mapViewGetters.getSpotById({parentMapId: spot.mapId, spotId: spot.spotId});
+                this.map.setView(spotToFocus.coordinate, initZoomLevel);
+            },
         );
         this.watchStoreForDisplayMap();
         this.initMapDisplay();

--- a/src/components/Map/index.ts
+++ b/src/components/Map/index.ts
@@ -14,9 +14,6 @@ import { MapViewGetters } from '@/store/modules/MapViewModule/MapViewGetters';
 @Component
 export default class Map extends Vue {
     private map!: L.Map;
-    private centerLat: number = 35;
-    private centerLng: number = 139;
-    private zoomLevel: number = 15;
     private tileLayer!: L.TileLayer;
     private polygonLayer?: L.GeoJSON<GeoJsonObject>; // 表示されるポリゴンのレイヤー
     private routeLines?: L.Polyline[];
@@ -24,16 +21,14 @@ export default class Map extends Vue {
     private spotMarkers: L.Marker[] = [];
     private currentLocationMarker: CurrentLocationMarker = new CurrentLocationMarker([0, 0]);
     private zoomLevelThreshold: number = 19; // とりあえず仮で閾値決めてます
-    private mapIdToDisplay: number = mapViewGetters.rootMapId;
 
     /**
      * とりあえず地図の表示を行なっています．
      */
     public mounted() {
         const rootMapCenter: Coordinate = this.calculateCenter(mapViewGetters.rootMapBounds);
-        this.centerLat = rootMapCenter.lat;
-        this.centerLng = rootMapCenter.lng;
-        this.map = L.map('map').setView([this.centerLat, this.centerLng], this.zoomLevel);
+        const initZoomLevel: number = 18;
+        this.map = L.map('map').setView([rootMapCenter.lat, rootMapCenter.lng], initZoomLevel);
         this.tileLayer = L.tileLayer(
             'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
                 maxZoom: 23,
@@ -44,8 +39,8 @@ export default class Map extends Vue {
         this.map.on('move', this.updateIdOfCenterSpotInRootMap);
         this.map.zoomControl.setPosition('bottomright');
         store.watch(
-            (state, getters: MapViewGetters) => mapViewGetters.mapCenterPositionToFocus,
-            (value, oldValue) => this.map.setView(value, this.zoomLevel),
+            (state, getters: MapViewGetters) => mapViewGetters.spotToFocus,
+            (value, oldValue) => {},
         );
         this.initMapDisplay();
     }

--- a/src/components/SpotItem/index.ts
+++ b/src/components/SpotItem/index.ts
@@ -1,5 +1,6 @@
 import { Component, Prop, Vue, Watch } from 'vue-property-decorator';
 import { mapViewGetters, mapViewMutations } from '@/store';
+import { LatLngExpression } from 'leaflet';
 
 @Component
 export default class SpotItem extends Vue {
@@ -10,4 +11,10 @@ export default class SpotItem extends Vue {
     private distance!: number;
     @Prop()
     private spotId!: number;
+    @Prop()
+    private position!: LatLngExpression;
+
+    private moveMapViewToThisSpot(): void {
+        mapViewMutations.setMapCenterPositionToFocus(this.position);
+    }
 }

--- a/src/components/SpotItem/index.ts
+++ b/src/components/SpotItem/index.ts
@@ -11,10 +11,8 @@ export default class SpotItem extends Vue {
     private distance!: number;
     @Prop()
     private spotId!: number;
-    @Prop()
-    private position!: LatLngExpression;
 
     private moveMapViewToThisSpot(): void {
-        mapViewMutations.setMapCenterPositionToFocus(this.position);
+        // mapViewMutations.setSpotToFocus({ mapId: this.mapId, spotId: this.spotId });
     }
 }

--- a/src/components/SpotItem/index.ts
+++ b/src/components/SpotItem/index.ts
@@ -19,6 +19,6 @@ export default class SpotItem extends Vue {
     private spotId!: number;
 
     private moveMapViewToThisSpot(): void {
-        mapViewMutations.setSpotToFocus({ mapId: this.mapId, spotId: this.spotId });
+        mapViewMutations.setSpotToDisplayInMapCenter({ mapId: this.mapId, spotId: this.spotId });
     }
 }

--- a/src/components/SpotItem/index.ts
+++ b/src/components/SpotItem/index.ts
@@ -19,6 +19,6 @@ export default class SpotItem extends Vue {
     private spotId!: number;
 
     private moveMapViewToThisSpot(): void {
-        // mapViewMutations.setSpotToFocus({ mapId: this.mapId, spotId: this.spotId });
+        mapViewMutations.setSpotToFocus({ mapId: this.mapId, spotId: this.spotId });
     }
 }

--- a/src/components/SpotItem/index.vue
+++ b/src/components/SpotItem/index.vue
@@ -2,13 +2,12 @@
 	<div id="spot-item">
         <v-card
             tile
+            @click="moveMapViewToThisSpot()"
         >
             <v-list-item two-line>
                 <v-list-item-content>
-                    <div @click="moveMapViewToThisSpot()">
-                        <v-list-item-title class="headline">{{ parentSpotName + " " + spotName }}</v-list-item-title>
-                        <v-list-item-subtitle>{{ floorName + " " + distance }}</v-list-item-subtitle>
-                    </div>
+                    <v-list-item-title class="headline">{{ parentSpotName + " " + spotName }}</v-list-item-title>
+                    <v-list-item-subtitle>{{ floorName + " " + distance }}</v-list-item-subtitle>
                 </v-list-item-content>
             </v-list-item>
         </v-card>

--- a/src/components/SpotItem/index.vue
+++ b/src/components/SpotItem/index.vue
@@ -6,8 +6,8 @@
             <v-list-item two-line>
                 <v-list-item-content>
                     <div @click="moveMapViewToThisSpot()">
-                    <v-list-item-title class="headline">{{ spotName }}</v-list-item-title>
-                    <v-list-item-subtitle>{{ distance }}</v-list-item-subtitle>
+                        <v-list-item-title class="headline">{{ spotName }}</v-list-item-title>
+                        <v-list-item-subtitle>{{ distance }}</v-list-item-subtitle>
                     </div>
                 </v-list-item-content>
             </v-list-item>

--- a/src/components/SpotItem/index.vue
+++ b/src/components/SpotItem/index.vue
@@ -5,8 +5,10 @@
         >
             <v-list-item two-line>
                 <v-list-item-content>
+                    <div @click="moveMapViewToThisSpot()">
                     <v-list-item-title class="headline">{{ spotName }}</v-list-item-title>
                     <v-list-item-subtitle>{{ distance }}</v-list-item-subtitle>
+                    </div>
                 </v-list-item-content>
             </v-list-item>
         </v-card>

--- a/src/components/SpotList/index.vue
+++ b/src/components/SpotList/index.vue
@@ -9,6 +9,7 @@
                 :spotId="spotSearchResult.id"
                 :spotName="spotSearchResult.name"
                 :distance="'1000km'"
+                :position="spotSearchResult.coordinate"
             >
             </SpotItem>
         </v-list>

--- a/src/store/modules/MapViewModule/MapViewGetters.ts
+++ b/src/store/modules/MapViewModule/MapViewGetters.ts
@@ -159,8 +159,8 @@ export class MapViewGetters extends Getters<MapViewState> {
         return this.state.idOfCenterSpotInRootMap;
     }
 
-    get spotToFocus(): { mapId: number, spotId: number } {
-        return this.state.spotToFocus;
+    get spotToDisplayInMapCenter(): { mapId: number, spotId: number } {
+        return this.state.spotToDisplayInMapCenter;
     }
 
      /* 経由するノードidの配列を入力することで経路となるノードの配列を取得

--- a/src/store/modules/MapViewModule/MapViewGetters.ts
+++ b/src/store/modules/MapViewModule/MapViewGetters.ts
@@ -159,8 +159,8 @@ export class MapViewGetters extends Getters<MapViewState> {
         return this.state.idOfCenterSpotInRootMap;
     }
 
-    get mapCenterPositionToFocus(): LatLngExpression {
-        return this.state.mapCenterPositionToFocus;
+    get spotToFocus(): { mapId: number, spotId: number } {
+        return this.state.spotToFocus;
     }
 
      /* 経由するノードidの配列を入力することで経路となるノードの配列を取得

--- a/src/store/modules/MapViewModule/MapViewGetters.ts
+++ b/src/store/modules/MapViewModule/MapViewGetters.ts
@@ -4,6 +4,7 @@ import { Map, Spot, SpotInfo, SpotForMap, Bounds, DisplayLevelType, Coordinate, 
 import { NoDetailMapsError } from '@/store/errors/NoDetailMapsError';
 import { MapNotFoundError } from '@/store/errors/MapNotFoundError';
 import { SpotNotFoundError } from '@/store/errors/SpotNotFoundError';
+import { LatLngExpression } from 'leaflet';
 
 export class MapViewGetters extends Getters<MapViewState> {
     /**
@@ -156,6 +157,10 @@ export class MapViewGetters extends Getters<MapViewState> {
      */
     get idOfCenterSpotInRootMap(): number | null {
         return this.state.idOfCenterSpotInRootMap;
+    }
+
+    get mapCenterPositionToFocus(): LatLngExpression {
+        return this.state.mapCenterPositionToFocus;
     }
 
      /* 経由するノードidの配列を入力することで経路となるノードの配列を取得

--- a/src/store/modules/MapViewModule/MapViewMutations.ts
+++ b/src/store/modules/MapViewModule/MapViewMutations.ts
@@ -76,8 +76,8 @@ export class MapViewMutations extends Mutations<MapViewState> {
         this.state.idOfCenterSpotInRootMap = null;
     }
 
-    public setSpotToFocus(spot: { mapId: number, spotId: number }): void {
-        this.state.spotToFocus = spot;
+    public setSpotToDisplayInMapCenter(spot: { mapId: number, spotId: number }): void {
+        this.state.spotToDisplayInMapCenter = spot;
     }
 
     /**

--- a/src/store/modules/MapViewModule/MapViewMutations.ts
+++ b/src/store/modules/MapViewModule/MapViewMutations.ts
@@ -76,8 +76,8 @@ export class MapViewMutations extends Mutations<MapViewState> {
         this.state.idOfCenterSpotInRootMap = null;
     }
 
-    public setMapCenterPositionToFocus(centerPosition: LatLngExpression): void {
-        this.state.mapCenterPositionToFocus = centerPosition;
+    public setSpotToFocus(spot: { mapId: number, spotId: number }): void {
+        this.state.spotToFocus = spot;
     }
 
     /**

--- a/src/store/modules/MapViewModule/MapViewMutations.ts
+++ b/src/store/modules/MapViewModule/MapViewMutations.ts
@@ -3,6 +3,7 @@ import { MapViewState } from './MapViewState';
 import { Map, Spot, DisplayLevelType } from '@/store/types';
 import { NoDetailMapIdInSpotError } from '@/store/errors/NoDetailMapIdInSpotError';
 import { mapViewGetters } from '@/store';
+import { LatLngExpression } from 'leaflet';
 
 export class MapViewMutations extends Mutations<MapViewState> {
     /**
@@ -73,6 +74,10 @@ export class MapViewMutations extends Mutations<MapViewState> {
      */
     public setNonExistentOfCenterSpotInRootMap(): void {
         this.state.idOfCenterSpotInRootMap = null;
+    }
+
+    public setMapCenterPositionToFocus(centerPosition: LatLngExpression): void {
+        this.state.mapCenterPositionToFocus = centerPosition;
     }
 
     /**

--- a/src/store/modules/MapViewModule/MapViewState.ts
+++ b/src/store/modules/MapViewModule/MapViewState.ts
@@ -45,5 +45,5 @@ export class MapViewState {
      */
     public displayLevel: DisplayLevelType = 'default';
 
-    public mapCenterPositionToFocus: LatLngExpression = { lat: 0, lng: 0 };
+    public spotToFocus: { mapId: number, spotId: number } = { mapId: 0, spotId: 0 };
 }

--- a/src/store/modules/MapViewModule/MapViewState.ts
+++ b/src/store/modules/MapViewModule/MapViewState.ts
@@ -1,5 +1,6 @@
 import { Map, DisplayLevelType } from '@/store/types';
 import { sampleMaps } from '@/store/modules/sampleMaps';
+import { LatLngExpression } from 'leaflet';
 
 export class MapViewState {
     /**
@@ -43,4 +44,6 @@ export class MapViewState {
      * ズームレベルに応じて切り替わる表示レベルを保持
      */
     public displayLevel: DisplayLevelType = 'default';
+
+    public mapCenterPositionToFocus: LatLngExpression = { lat: 0, lng: 0 };
 }

--- a/src/store/modules/MapViewModule/MapViewState.ts
+++ b/src/store/modules/MapViewModule/MapViewState.ts
@@ -80,5 +80,5 @@ export class MapViewState {
      */
     public displayLevel: DisplayLevelType = 'default';
 
-    public spotToFocus: { mapId: number, spotId: number } = { mapId: 0, spotId: 0 };
+    public spotToDisplayInMapCenter: { mapId: number, spotId: number } = { mapId: 0, spotId: 0 };
 }

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -13,7 +13,7 @@ export interface MapViewState {
     spotInfoIsVisible: boolean;
     displayLevel: DisplayLevelType;
     idOfCenterSpotInRootMap: number | null;
-    mapCenterPositionToFocus: LatLngExpression;
+    spotToFocus: { mapId: number, spotId: number };
 }
 
 /**

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -13,7 +13,7 @@ export interface MapViewState {
     spotInfoIsVisible: boolean;
     displayLevel: DisplayLevelType;
     idOfCenterSpotInRootMap: number | null;
-    spotToFocus: { mapId: number, spotId: number };
+    spotToDisplayInMapCenter: { mapId: number, spotId: number };
 }
 
 /**

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -1,3 +1,5 @@
+import { LatLngExpression } from 'leaflet';
+
 /**
  * MapViewコンポーネントの状態の情報を持つ型
  */
@@ -11,6 +13,7 @@ export interface MapViewState {
     spotInfoIsVisible: boolean;
     displayLevel: DisplayLevelType;
     idOfCenterSpotInRootMap: number | null;
+    mapCenterPositionToFocus: LatLngExpression;
 }
 
 /**

--- a/tests/resources/testMapViewState.ts
+++ b/tests/resources/testMapViewState.ts
@@ -205,6 +205,6 @@ export const testMapViewState: MapViewState = {
     spotInfoIsVisible: false,
     displayLevel: 'default',
     idOfCenterSpotInRootMap: null,
-    mapCenterPositionToFocus: { lat: 0, lng: 0 } ,
+    spotToFocus: { mapId: 0, spotId: 0 },
 };
 

--- a/tests/resources/testMapViewState.ts
+++ b/tests/resources/testMapViewState.ts
@@ -205,6 +205,6 @@ export const testMapViewState: MapViewState = {
     spotInfoIsVisible: false,
     displayLevel: 'default',
     idOfCenterSpotInRootMap: null,
-    spotToFocus: { mapId: 0, spotId: 0 },
+    spotToDisplayInMapCenter: { mapId: 0, spotId: 0 },
 };
 

--- a/tests/resources/testMapViewState.ts
+++ b/tests/resources/testMapViewState.ts
@@ -205,5 +205,6 @@ export const testMapViewState: MapViewState = {
     spotInfoIsVisible: false,
     displayLevel: 'default',
     idOfCenterSpotInRootMap: null,
+    mapCenterPositionToFocus: { lat: 0, lng: 0 } ,
 };
 

--- a/tests/resources/testMapViewState2.ts
+++ b/tests/resources/testMapViewState2.ts
@@ -270,5 +270,6 @@ export const testMapViewState2: MapViewState = {
     spotInfoIsVisible: false,
     displayLevel: 'default',
     idOfCenterSpotInRootMap: null,
+    spotToFocus: { mapId: 0, spotId: 0 },
 };
 

--- a/tests/resources/testMapViewState2.ts
+++ b/tests/resources/testMapViewState2.ts
@@ -270,6 +270,6 @@ export const testMapViewState2: MapViewState = {
     spotInfoIsVisible: false,
     displayLevel: 'default',
     idOfCenterSpotInRootMap: null,
-    spotToFocus: { mapId: 0, spotId: 0 },
+    spotToDisplayInMapCenter: { mapId: 0, spotId: 0 },
 };
 

--- a/tests/unit/components/SpotInfoCard/SpotInfoCard.spec.ts
+++ b/tests/unit/components/SpotInfoCard/SpotInfoCard.spec.ts
@@ -102,7 +102,7 @@ const mapViewStoreTestData: MapViewState = {
     spotInfoIsVisible: false,
     displayLevel: 'default',
     idOfCenterSpotInRootMap: null,
-    mapCenterPositionToFocus: { lat: 0, lng: 0 },
+    spotToFocus: { mapId: 0, spotId: 0 },
 };
 
 describe('SpotInfoコンポーネントのテスト', () => {

--- a/tests/unit/components/SpotInfoCard/SpotInfoCard.spec.ts
+++ b/tests/unit/components/SpotInfoCard/SpotInfoCard.spec.ts
@@ -102,7 +102,7 @@ const mapViewStoreTestData: MapViewState = {
     spotInfoIsVisible: false,
     displayLevel: 'default',
     idOfCenterSpotInRootMap: null,
-    spotToFocus: { mapId: 0, spotId: 0 },
+    spotToDisplayInMapCenter: { mapId: 0, spotId: 0 },
 };
 
 describe('SpotInfoコンポーネントのテスト', () => {

--- a/tests/unit/components/SpotInfoCard/SpotInfoCard.spec.ts
+++ b/tests/unit/components/SpotInfoCard/SpotInfoCard.spec.ts
@@ -102,6 +102,7 @@ const mapViewStoreTestData: MapViewState = {
     spotInfoIsVisible: false,
     displayLevel: 'default',
     idOfCenterSpotInRootMap: null,
+    mapCenterPositionToFocus: { lat: 0, lng: 0 },
 };
 
 describe('SpotInfoコンポーネントのテスト', () => {


### PR DESCRIPTION
## 実装の概要
- Spotを検索して検索結果のSpotItemをクリックするとマップが移動
- detailMapに存在するスポットの時はズームレベルが上がる
- ズームや移動の処理はmapコンポーネント側に記述
- SpotItemコンポーネントとMapコンポーネントのデータのやりとりのためにStoreにstate追加

close #192
