### PR TITLE
Map clicked process

### DIFF
--- a/src/components/Map/Marker/DefaultSpotMarker.ts
+++ b/src/components/Map/Marker/DefaultSpotMarker.ts
@@ -56,6 +56,5 @@ export default class DefaultSpotMarker extends L.Marker {
     private updateFocusedMarker(): void {
         mapViewMutations.setFocusedSpot({mapId: this.mapId, spotId: this.spotId});
         mapViewMutations.setSpotInfoIsVisible(true);
-        this.setSelected(true);
     }
 }

--- a/src/components/Map/Marker/DefaultSpotMarker.ts
+++ b/src/components/Map/Marker/DefaultSpotMarker.ts
@@ -21,23 +21,23 @@ export default class DefaultSpotMarker extends L.Marker {
         this.spotId = spotId;
     }
 
-    public addTo(map: L.Map | L.LayerGroup<any>): this {
-        return super.addTo(map).on('click', this.updateFocusedMarker);
+    /**
+     * マーカーのmapIdとspotIdを返す
+     * @returns 自身のmapId, spotId
+     */
+    public getIdInfo(): {mapId: number, spotId: number} {
+        return {mapId: this.mapId, spotId: this.spotId};
     }
 
-    /**
-     * マーカーが押されたときに呼び出されるコールバック関数
-     */
-    private updateFocusedMarker(): void {
-        mapViewMutations.setFocusedSpot({mapId: this.mapId, spotId: this.spotId});
-        mapViewMutations.setSpotInfoIsVisible(true);
+    public addTo(map: L.Map | L.LayerGroup<any>): this {
+        return super.addTo(map).on('click', this.updateFocusedMarker);
     }
 
     /**
      * マーカーの選択状態によって色を切り替える
      * @param isSelected true/false
      */
-    private setSelected(isSelected: boolean): void {
+    public setSelected(isSelected: boolean): void {
         this.isSelected = isSelected;
         const color = isSelected ? this.selectedColor : this.normalColor;
         const htmlTemplate =
@@ -48,5 +48,14 @@ export default class DefaultSpotMarker extends L.Marker {
             iconAnchor: [24, 50],
         });
         this.setIcon(icon);
+    }
+
+    /**
+     * マーカーが押されたときに呼び出されるコールバック関数
+     */
+    private updateFocusedMarker(): void {
+        mapViewMutations.setFocusedSpot({mapId: this.mapId, spotId: this.spotId});
+        mapViewMutations.setSpotInfoIsVisible(true);
+        this.setSelected(true);
     }
 }

--- a/src/components/Map/Marker/DefaultSpotMarker.ts
+++ b/src/components/Map/Marker/DefaultSpotMarker.ts
@@ -1,5 +1,5 @@
 import L, {Marker, LatLngExpression, LeafletEvent} from 'leaflet';
-import { mapViewMutations } from '@/store';
+import { mapViewMutations, mapViewGetters } from '@/store';
 import { MapViewState } from '@/store/modules/MapViewModule/MapViewState';
 
 export default class DefaultSpotMarker extends L.Marker {
@@ -19,6 +19,11 @@ export default class DefaultSpotMarker extends L.Marker {
         this.setIcon(this.icon);
         this.mapId = mapId;
         this.spotId = spotId;
+        // マーカー生成時にfocusedSpotの場合選択状態にしておく
+        const focusedSpot = mapViewGetters.focusedSpot;
+        if (focusedSpot.mapId === mapId && focusedSpot.spotId === spotId) {
+            this.setSelected(true);
+        }
     }
 
     /**

--- a/src/components/Map/index.ts
+++ b/src/components/Map/index.ts
@@ -22,6 +22,7 @@ export default class Map extends Vue {
     private spotMarkers: DefaultSpotMarker[] = [];
     private currentLocationMarker: CurrentLocationMarker = new CurrentLocationMarker([0, 0]);
     private zoomLevelThreshold: number = 19; // とりあえず仮で閾値決めてます
+    private mapIdToDisplay!: number;
 
     /**
      * とりあえず地図の表示を行なっています．

--- a/src/components/Map/index.ts
+++ b/src/components/Map/index.ts
@@ -71,7 +71,7 @@ export default class Map extends Vue {
     private onMapClick(): void {
         // focusedSpotがある場合そのスポットを未選択に設定する
         const focusedSpot = mapViewGetters.focusedSpot;
-        const focusedMarker = this.getMarkerByMapAndSpotId(focusedSpot);
+        const focusedMarker = this.findMarker(focusedSpot);
         if (focusedMarker !== null) {
             focusedMarker.setSelected(false);
         }
@@ -85,7 +85,7 @@ export default class Map extends Vue {
      * @param idInfo マーカーを取得したいspotの{mapId, spotId}
      * @returns 見つかったマーカーのオブジェクト | null
      */
-    private getMarkerByMapAndSpotId(idInfo: {mapId: number, spotId: number}): DefaultSpotMarker | null {
+    private findMarker(idInfo: {mapId: number, spotId: number}): DefaultSpotMarker | null {
         const foundMarker: DefaultSpotMarker | undefined = this.spotMarkers
             .find((marker) => {
                 return marker.getIdInfo().mapId === idInfo.mapId && marker.getIdInfo().spotId === idInfo.spotId;
@@ -109,12 +109,12 @@ export default class Map extends Vue {
                 // 古いfocusedSpotを非選択状態にする
                 // 表示するmapが変わった場合など，以前のfocusedMarkerが存在しない場合がある
                 // valueとoldValueは配列なので[0]で渡している
-                const oldSelectedMarker = this.getMarkerByMapAndSpotId(oldValue[0]);
+                const oldSelectedMarker = this.findMarker(oldValue[0]);
                 if (oldSelectedMarker != null) {
                     oldSelectedMarker.setSelected(false);
                 }
                 // 新しいfocusedSpotを選択状態にする
-                const newSelectedMarker = this.getMarkerByMapAndSpotId(value[0]);
+                const newSelectedMarker = this.findMarker(value[0]);
                 if (newSelectedMarker != null) {
                     newSelectedMarker.setSelected(true);
                 }

--- a/src/components/Map/index.ts
+++ b/src/components/Map/index.ts
@@ -21,7 +21,7 @@ export default class Map extends Vue {
     private polygonLayer?: L.GeoJSON<GeoJsonObject>; // 表示されるポリゴンのレイヤー
     private routeLines?: L.Polyline[];
     private routeLayer?: L.Layer;
-    private spotMarkers: L.Marker[] = [];
+    private spotMarkers: DefaultSpotMarker[] = [];
     private currentLocationMarker: CurrentLocationMarker = new CurrentLocationMarker([0, 0]);
     private zoomLevelThreshold: number = 19; // とりあえず仮で閾値決めてます
     private mapIdToDisplay: number = mapViewGetters.rootMapId;
@@ -60,6 +60,23 @@ export default class Map extends Vue {
         // sampleMapのポリゴン表示
         this.displayPolygons(rootMapSpots);
         this.currentLocationMarker.addTo(this.map);
+        // マーカー以外のmapがクリックされた時の処理を登録
+        this.map.on('click', this.onMapClick);
+    }
+
+    /**
+     * マーカーの選択状態を解除してSpotItemを非表示にする
+     */
+    private onMapClick(): void {
+        // focusedSpotがある場合そのスポットを未選択に設定する
+        const focusedSpot = mapViewGetters.focusedSpot;
+        this.spotMarkers
+            .filter((marker: DefaultSpotMarker) => marker.getIdInfo() === focusedSpot)
+            // mapId,spotIdの組み合わせでspotは一意に決まるはずなのでforEachはいらないけど
+            // filterの返り値が[]なのでとりあえずforEachにしてる
+            .forEach((marker: DefaultSpotMarker) => marker.setSelected(false));
+        // SpotItemを非表示にする
+        mapViewMutations.setSpotInfoIsVisible(false);
     }
 
     /**

--- a/src/components/Map/index.ts
+++ b/src/components/Map/index.ts
@@ -66,7 +66,7 @@ export default class Map extends Vue {
     }
 
     /**
-     * マーカーの選択状態を解除してSpotItemを非表示にする
+     * マーカーの選択状態を解除してSpotInfoを非表示にする
      */
     private onMapClick(): void {
         // focusedSpotがある場合そのスポットを未選択に設定する

--- a/src/store/modules/MapViewModule/MapViewState.ts
+++ b/src/store/modules/MapViewModule/MapViewState.ts
@@ -56,8 +56,8 @@ export class MapViewState {
      * Mapコンポーネントで選択されているMap，およびスポットのID
      */
     public focusedSpot: {mapId: number, spotId: number} = {
-        mapId: 0,
-        spotId: 0,
+        mapId: -1,
+        spotId: -1,
     };
 
     /**

--- a/tests/unit/components/Map/defaultSpotMarker.spec.ts
+++ b/tests/unit/components/Map/defaultSpotMarker.spec.ts
@@ -14,6 +14,14 @@ describe('DefaultSpotMarkers', () => {
         expect(spotMarker.getLatLng()).toStrictEqual(expectedMarker.getLatLng());
     });
 
+    it('コンストラクタに渡したmapId, spotIdを取得する', () => {
+        const expectedMapId = 0;
+        const expectedSpotId = 0;
+        const testMarker = new DefaultSpotMarker([0, 0], expectedMapId, expectedSpotId);
+        expect(testMarker.getIdInfo().mapId).toBe(expectedMapId);
+        expect(testMarker.getIdInfo().spotId).toBe(expectedSpotId);
+    });
+
     it('updateFocusedMarkerがmapIdとspotIdをfocusedSpotにsetする', () => {
         const testMarker = new DefaultSpotMarker([0, 0], 0, 1);
         (testMarker as any).updateFocusedMarker();

--- a/tests/unit/components/Map/mapMarkerSelect.spec.ts
+++ b/tests/unit/components/Map/mapMarkerSelect.spec.ts
@@ -46,7 +46,7 @@ describe('components/Map.vue マーカー選択関連のテスト', () => {
         expect(foundMarker.getIdInfo().spotId).toBe(expectedSpotId);
     });
 
-    it('onMapClickでfocusedSpotを非選択状態にしてSpotItemを非表示にする', () => {
+    it('onMapClickでfocusedSpotを非選択状態にしてSpotInfoを非表示にする', () => {
         const mapId = 0;
         const spotId = 1;
         const marker = new DefaultSpotMarker([0, 0], mapId, spotId);

--- a/tests/unit/components/Map/mapMarkerSelect.spec.ts
+++ b/tests/unit/components/Map/mapMarkerSelect.spec.ts
@@ -38,10 +38,10 @@ describe('components/Map.vue マーカー選択関連のテスト', () => {
             wrapper.vm.spotMarkers.push(new DefaultSpotMarker([0, 0], mapId, i));
         }
         // 存在しないidを指定した場合
-        expect(wrapper.vm.getMarkerByMapAndSpotId({mapId: 999, spotId: 999})).toBe(null);
+        expect(wrapper.vm.findMarker({mapId: 999, spotId: 999})).toBe(null);
         // 存在するidの場合
         const expectedSpotId = 1;
-        const foundMarker = wrapper.vm.getMarkerByMapAndSpotId({mapId, spotId: expectedSpotId});
+        const foundMarker = wrapper.vm.findMarker({mapId, spotId: expectedSpotId});
         expect(foundMarker.getIdInfo().mapId).toBe(mapId);
         expect(foundMarker.getIdInfo().spotId).toBe(expectedSpotId);
     });
@@ -53,7 +53,7 @@ describe('components/Map.vue マーカー選択関連のテスト', () => {
         marker.setSelected(true);
         mapViewMutations.setFocusedSpot({mapId, spotId});
         // focusedMarkerを探す部分をモック
-        wrapper.vm.getMarkerByMapAndSpotId = jest.fn((focusedSpot) => {
+        wrapper.vm.findMarker = jest.fn((focusedSpot) => {
             return marker;
         });
         wrapper.vm.onMapClick();

--- a/tests/unit/components/Map/mapMarkerSelect.spec.ts
+++ b/tests/unit/components/Map/mapMarkerSelect.spec.ts
@@ -1,0 +1,66 @@
+import { mapViewGetters, mapViewMutations } from '@/store';
+import { MapViewState, SpotForMap, Coordinate } from '@/store/types';
+import { shallowMount } from '@vue/test-utils';
+import { GeolocationWrapper } from '@/components/Map/GeolocationWrapper';
+import Vue from 'vue';
+import Map from '@/components/Map';
+import 'leaflet/dist/leaflet.css';
+import L, { map } from 'leaflet';
+import { cloneDeep } from 'lodash';
+import { testMapViewState } from '../../../resources/testMapViewState';
+import DefaultSpotMarker from '@/components/Map/Marker/DefaultSpotMarker';
+
+const mapViewStoreTestData: MapViewState = cloneDeep(testMapViewState);
+
+describe('components/Map.vue マーカー選択関連のテスト', () => {
+    let wrapper: any;
+    beforeEach(() => {
+        mapViewMutations.setMapViewState(mapViewStoreTestData);
+        GeolocationWrapper.watchPosition = jest.fn();
+        const initMapDisplay = jest.fn();
+        wrapper = shallowMount(Map, {
+            attachToDocument: true,
+            methods: {
+                initMapDisplay,
+            },
+        });
+    });
+
+    afterEach(() => {
+        // Map components already initialized防止
+        wrapper.destroy();
+    });
+
+    it('現在表示中のマーカーの中からmapIdとspotIdによってマーカーを取得する', () => {
+        const mapId = 0;
+        // (mapId, spotId) = (0, i)のマーカーを作成
+        for (let i = 0; i < 5; i++) {
+            wrapper.vm.spotMarkers.push(new DefaultSpotMarker([0, 0], mapId, i));
+        }
+        // 存在しないidを指定した場合
+        expect(wrapper.vm.getMarkerByMapAndSpotId({mapId: 999, spotId: 999})).toBe(null);
+        // 存在するidの場合
+        const expectedSpotId = 1;
+        const foundMarker = wrapper.vm.getMarkerByMapAndSpotId({mapId, spotId: expectedSpotId});
+        expect(foundMarker.getIdInfo().mapId).toBe(mapId);
+        expect(foundMarker.getIdInfo().spotId).toBe(expectedSpotId);
+    });
+
+    it('onMapClickでfocusedSpotを非選択状態にしてSpotItemを非表示にする', () => {
+        const mapId = 0;
+        const spotId = 1;
+        const marker = new DefaultSpotMarker([0, 0], mapId, spotId);
+        marker.setSelected(true);
+        mapViewMutations.setFocusedSpot({mapId, spotId});
+        // focusedMarkerを探す部分をモック
+        wrapper.vm.getMarkerByMapAndSpotId = jest.fn((focusedSpot) => {
+            return marker;
+        });
+        wrapper.vm.onMapClick();
+
+        // 非選択状態になっている
+        expect((marker as any).isSelected).toBe(false);
+        // SpotItemが非表示になっている
+        expect(mapViewGetters.spotInfoIsVisible).toBe(false);
+    });
+});

--- a/tests/unit/components/Map/mapMarkerSelect.spec.ts
+++ b/tests/unit/components/Map/mapMarkerSelect.spec.ts
@@ -1,11 +1,9 @@
 import { mapViewGetters, mapViewMutations } from '@/store';
-import { MapViewState, SpotForMap, Coordinate } from '@/store/types';
+import { MapViewState } from '@/store/types';
 import { shallowMount } from '@vue/test-utils';
 import { GeolocationWrapper } from '@/components/Map/GeolocationWrapper';
-import Vue from 'vue';
 import Map from '@/components/Map';
 import 'leaflet/dist/leaflet.css';
-import L, { map } from 'leaflet';
 import { cloneDeep } from 'lodash';
 import { testMapViewState } from '../../../resources/testMapViewState';
 import DefaultSpotMarker from '@/components/Map/Marker/DefaultSpotMarker';


### PR DESCRIPTION
## 実装の概要
- マーカーを選択した時に選択状態にして色を変更する
- マーカー以外のマップをクリックした時にマーカーの選択状態を解除，SpotInfoを非表示にする
- 表示するマップを切り替える際に前の同じマップだった場合，マーカーとポリゴンを再描画しないように変更

## 問題点
- マップのダブルクリックでもクリックが発火してしまう

close #210 
