### PR TITLE
pointer-eventsを調整してボタン横のマップを触れるように調整

### DIFF
--- a/src/components/FloorSwitchButton/index.vue
+++ b/src/components/FloorSwitchButton/index.vue
@@ -32,5 +32,6 @@
 <style scoped>
 .v-btn-toggle {
   flex-direction: column;
+  pointer-events: auto;
 }
 </style>

--- a/src/components/MapView/index.vue
+++ b/src/components/MapView/index.vue
@@ -63,6 +63,7 @@ body,
   left: 0;
   top: 0;
   z-index: 1000;
+  pointer-events: none;
 }
 
 #bottom-container {
@@ -70,6 +71,7 @@ body,
   left: 0px;
   bottom: 0px;
   z-index: 1000;
+  pointer-events: none;
 }
 
 body {

--- a/src/components/SearchBox/index.vue
+++ b/src/components/SearchBox/index.vue
@@ -51,4 +51,7 @@
 
 <!-- Add "scoped" attribute to limit CSS to this component only -->
 <style scoped>
+.v-card {
+    pointer-events: auto;
+}
 </style>

--- a/src/components/SpotInfoCard/index.vue
+++ b/src/components/SpotInfoCard/index.vue
@@ -20,4 +20,7 @@
 
 <!-- Add "scoped" attribute to limit CSS to this component only -->
 <style scoped>
+#spot-info {
+    pointer-events: auto;
+}
 </style>

--- a/src/components/SpotList/index.vue
+++ b/src/components/SpotList/index.vue
@@ -28,5 +28,6 @@
 .v-list {
     /* SearchBoxのサイズと, ボトムの余白サイズを引いたものがSearchListのサイズになる */
     max-height: calc(100vh - (8vh + 16px) - 8px);
+    pointer-events: auto;
 }
 </style>


### PR DESCRIPTION
## 実装の概要
- mapView側でpointer-eventsをnoneに設定(表示はされるがさわれなくなる)
- 各コンポーネントのボタン要素とかだけをpointer-events: auto;に設定して触れるように
- Thanks to kenchalros !!!!!

close #247 
