### PR TITLE
getterの関数の一部を移動

### DIFF
--- a/src/Map/Map.ts
+++ b/src/Map/Map.ts
@@ -1,5 +1,6 @@
-import Spot from '@/Spot/Spot.ts';
-import { Bounds } from '@/store/types';
+import Spot from '@/Spot/Spot.ts'; 
+import { Bounds, SpotForMap } from '@/store/types';
+import { mapViewGetters, mapViewMutations } from '@/store';
 
 export default class Map {
     constructor(private id: number,
@@ -8,5 +9,23 @@ export default class Map {
                 private bounds: Bounds,
                 private parentSpot?: Spot,
                 private floorName?: string) {
+    }
+    
+    /**
+     * Mapコンポーネントがアイコン表示のために必要なスポットの情報を返す
+     * - vuex-module-decoratorsにおいて引数付きgetterはこの書き方になる
+     * @return Mapコンポーネントが必要なスポットの情報
+     */
+    private getSpotsForMap(): SpotForMap[] {
+        const spotsForMap: SpotForMap[] = this.spots.map((spot: Spot) => {
+            return {
+                mapId: this.id,
+                spotId: (spot as any).id,
+                name: (spot as any).name,
+                coordinate: (spot as any).coordinate,
+                shape: (spot as any).shape,
+            };
+        });
+        return spotsForMap;
     }
 }

--- a/src/Spot/Spot.ts
+++ b/src/Spot/Spot.ts
@@ -1,5 +1,7 @@
-import { Coordinate, Shape } from '@/store/types.ts';
+import { Coordinate, Shape, SpotInfo } from '@/store/types.ts';
 import Map from '@/Map/Map.ts';
+]import { mapViewGetters, mapViewMutations } from '@/store';
+import { NoDetailMapsError } from '@/store/errors/NoDetailMapsError';
 
 export default class Spot {
     constructor(private id: number,
@@ -11,5 +13,59 @@ export default class Spot {
                 private floorName?: string,
                 private description?: string,
                 private attachment?: [{name: string, url: string}]) {
+    }
+
+    /**
+     * 指定されたスポットが詳細マップを持つかどうかを判定する．
+     * @param targetSpot マップのIdとスポットのId
+     * @return スポットが詳細マップを持つならばtrue, 持たないならばfalse
+     */
+    private spotHasDetailMaps(): boolean {
+        const spot = mapViewGetters.getSpotById({parentMapId: (this.parentMap as any).id, spotId: this.id});
+        if (spot.detailMapIds.length > 0) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    /**
+     * スポットのもつ詳細マップのうち、最後に参照された詳細マップのIdを返す
+     * @return lastViewdDetailMapId スポットが持つ詳細マップのうち、最後に参照された詳細マップのId．
+     * まだ参照されていない場合はnullを返す．
+     * @throw NoDetailMapsError スポットが詳細マップを持っていない場合に発生.
+     */
+    private getLastViewedDetailMapId(): number | null {
+        if (this.spotHasDetailMaps() === false) {
+            throw new NoDetailMapsError('This spot has no detail maps...');
+        }
+        const spot = mapViewGetters.getSpotById({parentMapId: (this.parentMap as any).id, spotId: this.id});
+        const lastViewedDetailMapId: number | null = spot.lastViewedDetailMapId;
+        return lastViewedDetailMapId;
+    }
+
+    /**
+     * SpotInfoコンポーネントが表示する情報を返す
+     * @param targetSpot マップIdとスポットIdのオブジェクト
+     * @return SpotInfoコンポーネントに必要な情報*
+     */
+    private getSpotInfo(): SpotInfo {
+        const description: string =
+            this.description !== undefined ? this.description : '';
+        const attachment: [{name: string, url: string}] =
+            this.attachment !== undefined ? this.attachment : [{name: '', url: ''}];
+        return {name: this.name, description, attachment};
+    }
+
+    /**
+     * スポットの親スポットを探す
+     * 親スポットが存在しない場合はnullを返す
+     * @return 親スポット.存在しない場合null
+     */
+    private findParentSpotId(): number | null {
+        if ((this.parentMap as any).parentSpot.id !== undefined) {
+            return (this.parentMap as any).parentSpot.id;
+        }
+        return null;
     }
 }

--- a/src/store/modules/MapViewModule/MapViewGetters.ts
+++ b/src/store/modules/MapViewModule/MapViewGetters.ts
@@ -1,7 +1,6 @@
 import { Getters } from 'vuex-smart-module';
 import { MapViewState } from './MapViewState';
 import { Map, Spot, SpotInfo, SpotForMap, Bounds, DisplayLevelType, Coordinate, Node } from '@/store/types';
-import { NoDetailMapsError } from '@/store/errors/NoDetailMapsError';
 import { MapNotFoundError } from '@/store/errors/MapNotFoundError';
 import { SpotNotFoundError } from '@/store/errors/SpotNotFoundError';
 
@@ -31,24 +30,6 @@ export class MapViewGetters extends Getters<MapViewState> {
     }
 
     /**
-     * SpotInfoコンポーネントが表示する情報を返す
-     * @param targetSpot マップIdとスポットIdのオブジェクト
-     * @return SpotInfoコンポーネントに必要な情報*
-     */
-    public getSpotInfo(targetSpot: {mapId: number, spotId: number}): SpotInfo {
-        const spot: Spot = this.getters.getSpotById({
-            parentMapId: targetSpot.mapId,
-            spotId: targetSpot.spotId,
-        });
-        const name: string = spot.name;
-        const description: string =
-            spot.description !== undefined ? spot.description : '';
-        const attachment: [{name: string, url: string}] =
-            spot.attachment !== undefined ? spot.attachment : [{name: '', url: ''}];
-        return {name, description, attachment};
-    }
-
-    /**
      * SpotInfoコンポーネントの表示非表示状態を返す
      * @return 表示状態の場合true
      */
@@ -63,27 +44,6 @@ export class MapViewGetters extends Getters<MapViewState> {
     get rootMapBounds(): Bounds {
         const rootMapIndex: number = this.state.maps.findIndex((m: Map) => m.id === this.state.rootMapId);
         return this.state.maps[rootMapIndex].bounds;
-    }
-
-    /**
-     * Mapコンポーネントがアイコン表示のために必要なスポットの情報を返す
-     * - vuex-module-decoratorsにおいて引数付きgetterはこの書き方になる
-     * @param  mapId 必要なスポットが存在するマップのID
-     * @return Mapコンポーネントが必要なスポットの情報
-     */
-    public getSpotsForMap(mapId: number): SpotForMap[] {
-        const mapIndex: number = this.state.maps.findIndex((m: Map) => m.id === mapId);
-        const spots: Spot[] = this.state.maps[mapIndex].spots;
-        const spotsForMap: SpotForMap[] = spots.map((spot: Spot) => {
-            return {
-                mapId,
-                spotId: spot.id,
-                name: spot.name,
-                coordinate: spot.coordinate,
-                shape: spot.shape,
-            };
-        });
-        return spotsForMap;
     }
 
     /**
@@ -103,39 +63,6 @@ export class MapViewGetters extends Getters<MapViewState> {
             throw new SpotNotFoundError('Spot does not found...');
         }
         return spot;
-    }
-
-    /**
-     * 指定されたスポットが詳細マップを持つかどうかを判定する．
-     * @param targetSpot マップのIdとスポットのId
-     * @return スポットが詳細マップを持つならばtrue, 持たないならばfalse
-     */
-    public spotHasDetailMaps(targetSpot: {
-        parentMapId: number,
-        spotId: number,
-    }): boolean {
-        const spot = this.getters.getSpotById(targetSpot);
-        if (spot.detailMapIds.length > 0) {
-            return true;
-        } else {
-            return false;
-        }
-    }
-
-    /**
-     * スポットのもつ詳細マップのうち、最後に参照された詳細マップのIdを返す
-     * @param parentSpot どのマップのどのスポットかを示す情報.
-     * @return lastViewdDetailMapId スポットが持つ詳細マップのうち、最後に参照された詳細マップのId．
-     * まだ参照されていない場合はnullを返す．
-     * @throw NoDetailMapsError スポットが詳細マップを持っていない場合に発生.
-     */
-    public getLastViewedDetailMapId(parentSpot: {parentMapId: number, spotId: number}): number | null {
-        if (this.getters.spotHasDetailMaps(parentSpot) === false) {
-            throw new NoDetailMapsError('This spot has no detail maps...');
-        }
-        const spot = this.getters.getSpotById(parentSpot);
-        const lastViewedDetailMapId: number | null = spot.lastViewedDetailMapId;
-        return lastViewedDetailMapId;
     }
 
     /**
@@ -164,25 +91,6 @@ export class MapViewGetters extends Getters<MapViewState> {
      */
     get spotToDisplayInMapCenter(): { mapId: number, spotId: number } {
         return this.state.spotToDisplayInMapCenter;
-    }
-
-    /**
-     * スポットの親スポットを探す
-     * 親スポットが存在しない場合はnullを返す
-     * @param targetSpot 親スポットを探したいスポット
-     * @return 親スポット.存在しない場合null
-     */
-    public findParentSpotId(targetSpot: { mapId: number, spotId: number} ): number | null {
-        for (const map of this.state.maps) {
-            for (const spot of map.spots) {
-                for (const detailMapId of spot.detailMapIds) {
-                    if (detailMapId === targetSpot.mapId) {
-                        return spot.id;
-                    }
-                }
-            }
-        }
-        return null;
     }
 
     /**


### PR DESCRIPTION
## 実装の概要

close 267

## 実装の概要（旧）
getterとmutationでは、getとset以外の処理をさせたくないため、それ以外の処理を移行
