### PR TITLE
Map、Spotのadd処理内でset処理を、set処理内でadd処理を呼び出すように修正

### DIFF
--- a/src/Map/Map.ts
+++ b/src/Map/Map.ts
@@ -12,18 +12,47 @@ export default class Map {
     }
 
     /**
-     * 親スポットをセットする
-     * @params セットする親スポット
+     * 親spotをセットし,セットしたspotのdetailMapに自身を追加する.
+     * すでにセット済みであればセットしない.
+     * @param parentSpot セットする親スポット
      */
-    public setParentSpot(parentSpot: Spot) {
+    public setParentSpot(parentSpot: Spot): void {
+        if (this.hasParentSpot()) {
+            return;
+        }
         this.parentSpot = parentSpot;
+        parentSpot.addDetailMaps([this]);
     }
 
     /**
-     * スポットを追加する
-     * @params 追加するスポット
+     * spotを追加し,追加したspotのparentMapとして自身をセットする.
+     * すでに追加済みであれば追加しない.
+     * @param spots 追加するspotの配列
      */
-    public addSpots(spots: Spot[]) {
-        this.spots = this.spots.concat(spots);
+    public addSpots(spots: Spot[]): void {
+        for (const spot of spots) {
+            if (this.hasSpot(spot)) {
+                continue;
+            }
+            this.spots.push(spot);
+            spot.setParentMap(this);
+        }
+    }
+
+    /**
+     * parentSpotを持つかどうかを判定する
+     * @return parentSpotを持つならtrue, 持っていなければfalse
+     */
+    public hasParentSpot(): boolean {
+        return this.parentSpot !== undefined;
+    }
+
+    /**
+     * spotがすでに登録済みかを判定する
+     * @param spot 判定対象のspot
+     * @return すでに登録済みならtrue, 未登録ならばfalse
+     */
+    public hasSpot(spot: Spot): boolean {
+        return this.spots.includes(spot);
     }
 }

--- a/src/Spot/Spot.ts
+++ b/src/Spot/Spot.ts
@@ -15,18 +15,47 @@ export default class Spot {
     }
 
     /**
-     * 親マップをセットする
-     * @params セットする親マップ
+     * 親mapをセットし,セットしたmapの子spotに自身を追加する.
+     * すでにセット済みであればセットしない。
+     * @param parentMap セットする親map
      */
-    public setParentMap(parentMap: Map) {
+    public setParentMap(parentMap: Map): void {
+        if (this.hasParentMap()) {
+            return;
+        }
         this.parentMap = parentMap;
+        parentMap.addSpots([this]);
     }
 
     /**
-     * 詳細マップを追加する
-     * @params 追加する詳細マップの配列
+     * 詳細mapを追加し,追加した詳細mapにparentSpotとして自身をセットする.
+     * すでに追加済みであれば追加しない.
+     * @param detailMaps 追加する詳細マップの配列
      */
-    public addDetailMaps(detailMaps: Map[]) {
-        this.detailMaps = this.detailMaps.concat(detailMaps);
+    public addDetailMaps(detailMaps: Map[]): void {
+        for (const detailMap of detailMaps) {
+            if (this.hasDetailMap(detailMap)) {
+                continue;
+            }
+            this.detailMaps.push(detailMap);
+            detailMap.setParentSpot(this);
+        }
+    }
+
+    /**
+     * parentMapを持つかどうかを判定する
+     * @return parentMapを持つならtrue, 持っていなければfalse
+     */
+    public hasParentMap(): boolean {
+        return this.parentMap !== undefined;
+    }
+
+    /**
+     * 詳細mapがすでに登録済みかを判定する
+     * @param detailMap 判定対象のmap
+     * @return すでに登録済みならtrue, 未登録ならばfalse
+     */
+    public hasDetailMap(detailMap: Map): boolean {
+        return this.detailMaps.includes(detailMap);
     }
 }

--- a/src/store/modules/MapViewModule/MapViewState.ts
+++ b/src/store/modules/MapViewModule/MapViewState.ts
@@ -115,7 +115,7 @@ export class MapViewState {
      *   外部モジュールのsampleMapsで初期化
      * 将来的にはvuexのmutationで登録する
      */
-    // public maps: RawMap[] = initMaps();
+    public maps: RawMap[] = initMaps();
     /**
      * 新
      */

--- a/tests/unit/Map/mapAddSpots.spec.ts
+++ b/tests/unit/Map/mapAddSpots.spec.ts
@@ -19,4 +19,33 @@ describe('Mapクラスのスポット登録のテスト', () => {
         map.addSpots(testSpots);
         expect((map as any).spots).toStrictEqual(testSpots);
     });
+
+    it('登録済みspotは重複して登録しない', () => {
+        const testMap: Map = new Map(0, 'testMap', testBounds, undefined);
+        const testSpots = [];
+        for (let i = 0; i < 5; i++) {
+            testSpots.push(new Spot(i, 'testSpot', testCoord, undefined, undefined, undefined, undefined));
+        }
+        const spotDuplicated: Spot = new Spot(0, 'testSpot', testCoord, undefined, undefined, undefined, undefined);
+        testSpots.push(spotDuplicated);
+        testMap.addSpots(testSpots);
+        expect((testMap as any).spots).toStrictEqual(testSpots);
+    });
+
+    it('mapにspotを登録する際に、spotのparentMapとして自身をセットする', () => {
+        const testMap: Map = new Map(0, 'testMap', testBounds, undefined);
+        const testSpot: Spot = new Spot(0, 'testSpot', testCoord, undefined, undefined, undefined, undefined);
+        testMap.addSpots([testSpot]);
+        expect((testSpot as any).parentMap).toStrictEqual(testMap);
+    });
+
+    it('子spotが登録済みかどうかをhasSpotにより判定する', () => {
+        const testMap: Map = new Map(0, 'testMap', testBounds, undefined);
+        const testSpot: Spot = new Spot(0, 'testSpot', testCoord, undefined, undefined, undefined, undefined);
+        // 登録前の判定
+        expect(testMap.hasSpot(testSpot)).toBe(false);
+        // 登録後の判定
+        (testMap as any).spots.push(testSpot);
+        expect(testMap.hasSpot(testSpot)).toBe(true);
+    });
 });

--- a/tests/unit/Map/mapSetParentSpot.spec.ts
+++ b/tests/unit/Map/mapSetParentSpot.spec.ts
@@ -14,6 +14,34 @@ describe('Mapクラスの親スポット登録のテスト', () => {
         const testSpot = new Spot(0, 'testSpot', testCoord, undefined, undefined, undefined);
         // 登録
         map.setParentSpot(testSpot);
-        expect((map as any).parentSpot).toBe(testSpot);
+        expect((map as any).parentSpot).toStrictEqual(testSpot);
+    });
+
+    it('異なるparentSpotの登録は禁止する', () => {
+        map = new Map(0, 'testMap', testBounds, undefined);
+        const testSpot = new Spot(0, 'testSpot', testCoord, undefined, undefined, undefined);
+        const anotherSpot = new Spot(1, 'testSpot', testCoord, undefined, undefined, undefined);
+        // 登録
+        map.setParentSpot(testSpot);
+        map.setParentSpot(anotherSpot);
+        // 最初に登録されたparentSpotが登録されたままになる
+        expect((map as any).parentSpot).toStrictEqual(testSpot);
+    });
+
+    it('parentSpot登録時に、parentSpotのdetailMapとして自身を登録する', () => {
+        map = new Map(0, 'testMap', testBounds, undefined);
+        const testSpot = new Spot(0, 'testSpot', testCoord, undefined, undefined, undefined);
+        map.setParentSpot(testSpot);
+        expect((testSpot as any).detailMaps.includes(map)).toBe(true);
+    });
+
+    it('親spotが登録済みかどうかをhasParentSpotにより判定する', () => {
+        const testMap: Map = new Map(0, 'testMap', testBounds, undefined);
+        const testSpot: Spot = new Spot(0, 'testSpot', testCoord, undefined, undefined, undefined, undefined);
+        // 登録前の判定
+        expect(testMap.hasParentSpot()).toBe(false);
+        // 登録後の判定
+        (testMap as any).parentSpot = testSpot;
+        expect(testMap.hasParentSpot()).toBe(true);
     });
 });

--- a/tests/unit/Spot/spotAddDetailMaps.spec.ts
+++ b/tests/unit/Spot/spotAddDetailMaps.spec.ts
@@ -19,4 +19,33 @@ describe('Spotクラスの詳細マップ登録のテスト', () => {
         spot.addDetailMaps(testDetailMaps);
         expect((spot as any).detailMaps).toStrictEqual(testDetailMaps);
     });
+
+    it('登録済みmapは重複して登録しない', () => {
+        const testSpot: Spot = new Spot(0, 'testSpot', testCoord, undefined, undefined, undefined, undefined);
+        const testDetailMaps = [];
+        for (let i = 0; i < 5; i++) {
+            testDetailMaps.push(new Map(i, 'testMap', testBounds, undefined));
+        }
+        const mapDuplicated: Map = new Map(0, 'testMap', testBounds, undefined);
+        testDetailMaps.push(mapDuplicated);
+        testSpot.addDetailMaps(testDetailMaps);
+        expect((testSpot as any).detailMaps).toStrictEqual(testDetailMaps);
+    });
+
+    it('spotにdetialMapを登録する際に,detailMapのparentSpotとして自身をセットする', () => {
+        const testSpot: Spot = new Spot(0, 'testSpot', testCoord, undefined, undefined, undefined, undefined);
+        const testMap: Map = new Map(0, 'testMap', testBounds, undefined);
+        testSpot.addDetailMaps([testMap]);
+        expect((testMap as any).parentSpot).toStrictEqual(testSpot);
+    });
+
+    it('detailMapが登録済みかどうかをhasDetailMapにより判定する', () => {
+        const testSpot: Spot = new Spot(0, 'testSpot', testCoord, undefined, undefined, undefined, undefined);
+        const testMap: Map = new Map(0, 'testMap', testBounds, undefined);
+        // 登録前の判定
+        expect(testSpot.hasDetailMap(testMap)).toBe(false);
+        // 登録後の判定
+        (testSpot as any).detailMaps.push(testMap);
+        expect(testSpot.hasDetailMap(testMap)).toBe(true);
+    });
 });

--- a/tests/unit/Spot/spotSetParentMap.spec.ts
+++ b/tests/unit/Spot/spotSetParentMap.spec.ts
@@ -16,4 +16,32 @@ describe('Spotクラスの親マップ登録のテスト', () => {
         spot.setParentMap(testMap);
         expect((spot as any).parentMap).toBe(testMap);
     });
+
+    it('異なるparentMapの登録は禁止する', () => {
+        const testMap: Map = new Map(0, 'testMap', testBounds, undefined);
+        const anotherMap: Map = new Map(1, 'testMap', testBounds, undefined);
+        const testSpot = new Spot(0, 'testSpot', testCoord, undefined, undefined, undefined);
+        // 登録
+        testSpot.setParentMap(testMap);
+        testSpot.setParentMap(anotherMap);
+        // 最初に登録されたparentSpotが登録されたままになる
+        expect((testSpot as any).parentMap).toStrictEqual(testMap);
+    });
+
+    it('parentMap登録時に、parentMapの子spotとして自身を登録する', () => {
+        const testMap: Map = new Map(0, 'testMap', testBounds, undefined);
+        const testSpot = new Spot(0, 'testSpot', testCoord, undefined, undefined, undefined);
+        testSpot.setParentMap(testMap);
+        expect((testMap as any).spots.includes(testSpot)).toBe(true);
+    });
+
+    it('親マップが登録済みかどうかをhasParentMapにより判定する', () => {
+        const testMap: Map = new Map(0, 'testMap', testBounds, undefined);
+        const testSpot: Spot = new Spot(0, 'testSpot', testCoord, undefined, undefined, undefined, undefined);
+        // 登録前の判定
+        expect(testSpot.hasParentMap()).toBe(false);
+        // 登録後の判定
+        (testSpot as any).parentMap = testMap;
+        expect(testSpot.hasParentMap()).toBe(true);
+    });
 });

--- a/tests/unit/store/modules/MapViewState.spec.ts
+++ b/tests/unit/store/modules/MapViewState.spec.ts
@@ -2,7 +2,7 @@ import { RawMap } from '@/store/types';
 import { testMapViewState3 } from '../../../resources/testMapViewState3';
 import Map from '@/Map/Map.ts';
 import Spot from '@/Spot/Spot.ts';
-import { createMapInstance, createSpotInstance, toMapTree } from '@/store/modules/MapViewmodule/MapViewState.ts';
+import { createMapInstance, createSpotInstance, toMapTree } from '@/store/modules/MapViewmodule/MapViewState';
 
 describe('MapViewState.tsのテスト', () => {
     it('createMapInstanceがMap型を返す', () => {

--- a/tests/unit/store/modules/MapViewState.spec.ts
+++ b/tests/unit/store/modules/MapViewState.spec.ts
@@ -2,7 +2,7 @@ import { RawMap } from '@/store/types';
 import { testMapViewState3 } from '../../../resources/testMapViewState3';
 import Map from '@/Map/Map.ts';
 import Spot from '@/Spot/Spot.ts';
-import { createMapInstance, createSpotInstance, toMapTree } from '@/store/modules/MapViewmodule/MapViewState';
+import { createMapInstance, createSpotInstance, toMapTree } from '@/store/modules/MapViewModule/MapViewState.ts';
 
 describe('MapViewState.tsのテスト', () => {
     it('createMapInstanceがMap型を返す', () => {


### PR DESCRIPTION
## 実装の概要
Mapのadd処理内でSpotのset処理を、set処理内でSpotのadd処理を呼び出すように機能を追加しました。（逆にSpot側はMapの処理を呼び出します。）
これにより、
```typescript
map.addSpots([spot]);
spot.setParentMap(map);
```
という呼び出しを、
```typescript
map.addSpots([spot])
```
もしくは
```typescript
spot.setParentMap(map)
```
にまとめることができます。（両方呼んでも大丈夫ですが、状態は変わりません）

close #279 
