### PR TITLE
SpotクラスにlastViewedMapメンバとそのゲッターセッターを追加

### DIFF
--- a/src/Spot/Spot.ts
+++ b/src/Spot/Spot.ts
@@ -4,6 +4,7 @@ import Map from '@/Map/Map.ts';
 export default class Spot {
     private parentMap: Map | undefined = undefined;
     private detailMaps: Map[] = [];
+    private lastViewedDetailMap: Map | undefined = undefined;
 
     constructor(private id: number,
                 private name: string,
@@ -16,7 +17,7 @@ export default class Spot {
 
     /**
      * 親マップをセットする
-     * @params セットする親マップ
+     * @param parentMap セットする親マップ
      */
     public setParentMap(parentMap: Map) {
         this.parentMap = parentMap;
@@ -24,9 +25,29 @@ export default class Spot {
 
     /**
      * 詳細マップを追加する
-     * @params 追加する詳細マップの配列
+     * @param detailMaps 追加する詳細マップの配列
      */
     public addDetailMaps(detailMaps: Map[]) {
         this.detailMaps = this.detailMaps.concat(detailMaps);
+        // lastViewedDetailMapの初期化
+        if (this.lastViewedDetailMap === undefined && detailMaps.length > 0) {
+            this.lastViewedDetailMap = detailMaps[0];
+        }
+    }
+
+    /**
+     * 最後に表示された詳細マップを返す
+     * @return 最後に表示された詳細マップ
+     */
+    public getLastViewedDetailMap(): Map | undefined {
+        return this.lastViewedDetailMap;
+    }
+
+    /**
+     * 最後に表示された詳細マップを更新する
+     * @param lastViewedDetailMap 最後に表示された詳細マップ
+     */
+    public setLastViewedDetailMap(lastViewedDetailMap: Map): void {
+        this.lastViewedDetailMap = lastViewedDetailMap;
     }
 }

--- a/tests/unit/Spot/spotAddDetailMaps.spec.ts
+++ b/tests/unit/Spot/spotAddDetailMaps.spec.ts
@@ -19,4 +19,12 @@ describe('Spotクラスの詳細マップ登録のテスト', () => {
         spot.addDetailMaps(testDetailMaps);
         expect((spot as any).detailMaps).toStrictEqual(testDetailMaps);
     });
+
+    it('詳細マップ追加時にlastViewedDetailMapが初期化されていない場合初期化される', () => {
+        spot = new Spot(0, 'testSpot', testCoord);
+        const testDetailMaps: Map[] = [new Map(0, 'testMap', testBounds)];
+        // 登録
+        spot.addDetailMaps(testDetailMaps);
+        expect(spot.getLastViewedDetailMap()).toStrictEqual(testDetailMaps[0]);
+    });
 });

--- a/tests/unit/Spot/spotAddDetailMaps.spec.ts
+++ b/tests/unit/Spot/spotAddDetailMaps.spec.ts
@@ -2,18 +2,17 @@ import Spot from '@/Spot/Spot.ts';
 import Map from '@/Map/Map.ts';
 
 describe('Spotクラスの詳細マップ登録のテスト', () => {
-    let spot: Spot;
     const testBounds = {
         topL: {lat: 0, lng: 0},
         botR: {lat: 0, lng: 0},
     };
     const testCoord = { lat: 0, lng: 0 };
+    const spot = new Spot(0, 'testSpot', testCoord);
 
     it('指定した詳細マップがdetailMapsに追加される', () => {
-        spot = new Spot(0, 'testSpot', testCoord, undefined, undefined, undefined, undefined);
         const testDetailMaps = [];
         for (let i = 0; i < 5; i++) {
-            testDetailMaps.push(new Map(i, 'testMap', testBounds, undefined));
+            testDetailMaps.push(new Map(i, 'testMap', testBounds));
         }
         // 登録
         spot.addDetailMaps(testDetailMaps);
@@ -21,10 +20,19 @@ describe('Spotクラスの詳細マップ登録のテスト', () => {
     });
 
     it('詳細マップ追加時にlastViewedDetailMapが初期化されていない場合初期化される', () => {
-        spot = new Spot(0, 'testSpot', testCoord);
         const testDetailMaps: Map[] = [new Map(0, 'testMap', testBounds)];
         // 登録
         spot.addDetailMaps(testDetailMaps);
+        expect(spot.getLastViewedDetailMap()).toStrictEqual(testDetailMaps[0]);
+    });
+
+    it('詳細マップ追加時にlastViewedDetailMapが初期化されている場合初期化されない', () => {
+        const testDetailMaps: Map[] = [new Map(0, 'testMap', testBounds)];
+        const testDetailMaps2: Map[] = [new Map(1, 'testMap2', testBounds)];
+        // 登録
+        spot.addDetailMaps(testDetailMaps);
+        spot.addDetailMaps(testDetailMaps2);
+        expect(spot.getLastViewedDetailMap()).not.toStrictEqual(testDetailMaps2[0]);
         expect(spot.getLastViewedDetailMap()).toStrictEqual(testDetailMaps[0]);
     });
 });

--- a/tests/unit/Spot/spotAddDetailMaps.spec.ts
+++ b/tests/unit/Spot/spotAddDetailMaps.spec.ts
@@ -7,13 +7,13 @@ describe('Spotクラスの詳細マップ登録のテスト', () => {
         botR: {lat: 0, lng: 0},
     };
     const testCoord = { lat: 0, lng: 0 };
-    const spot = new Spot(0, 'testSpot', testCoord);
 
     it('指定した詳細マップがdetailMapsに追加される', () => {
         const testDetailMaps = [];
         for (let i = 0; i < 5; i++) {
             testDetailMaps.push(new Map(i, 'testMap', testBounds));
         }
+        const spot = new Spot(0, 'testSpot', testCoord);
         // 登録
         spot.addDetailMaps(testDetailMaps);
         expect((spot as any).detailMaps).toStrictEqual(testDetailMaps);
@@ -21,6 +21,7 @@ describe('Spotクラスの詳細マップ登録のテスト', () => {
 
     it('詳細マップ追加時にlastViewedDetailMapが初期化されていない場合初期化される', () => {
         const testDetailMaps: Map[] = [new Map(0, 'testMap', testBounds)];
+        const spot = new Spot(0, 'testSpot', testCoord);
         // 登録
         spot.addDetailMaps(testDetailMaps);
         expect(spot.getLastViewedDetailMap()).toStrictEqual(testDetailMaps[0]);
@@ -29,6 +30,7 @@ describe('Spotクラスの詳細マップ登録のテスト', () => {
     it('詳細マップ追加時にlastViewedDetailMapが初期化されている場合初期化されない', () => {
         const testDetailMaps: Map[] = [new Map(0, 'testMap', testBounds)];
         const testDetailMaps2: Map[] = [new Map(1, 'testMap2', testBounds)];
+        const spot = new Spot(0, 'testSpot', testCoord);
         // 登録
         spot.addDetailMaps(testDetailMaps);
         spot.addDetailMaps(testDetailMaps2);

--- a/tests/unit/Spot/spotLastDetailMap.spec.ts
+++ b/tests/unit/Spot/spotLastDetailMap.spec.ts
@@ -1,0 +1,25 @@
+import Spot from '@/Spot/Spot.ts';
+import Map from '@/Map/Map.ts';
+
+describe('lastViewedDetailMap関連のテスト', () => {
+    const testBounds = {
+        topL: {lat: 0, lng: 0},
+        botR: {lat: 0, lng: 0},
+    };
+    const testCoord = { lat: 0, lng: 0 };
+
+    it('getLastViewedDetailMapメソッドのテスト', () => {
+        const spot = new Spot(0, 'testSpot', testCoord);
+        const expectedMap = new Map(0, 'testMap', testBounds);
+        (spot as any).lastViewedDetailMap = expectedMap;
+        const actualMap = spot.getLastViewedDetailMap();
+        expect(actualMap).toStrictEqual(expectedMap);
+    });
+
+    it('setLastViewedDetailMapメソッドのテスト', () => {
+        const spot = new Spot(0, 'testSpot', testCoord);
+        const expectedMap = new Map(0, 'testMap', testBounds);
+        spot.setLastViewedDetailMap(expectedMap);
+        expect(spot.getLastViewedDetailMap()).toStrictEqual(expectedMap);
+    });
+});


### PR DESCRIPTION
Co-authored-by: nishikawa1122 <nishikawa@posl.ait.kyushu-u.ac.jp>
Co-authored-by: ooka hidenori <45028997+ooka-hidenori@users.noreply.github.com>

## 実装の概要
- SpotクラスにlastViewedDetailMapメンバを追加
- addDetailMapsメソッドで初期化を行うように変更

close #261
