### PR TITLE
マップ選択時のポップアップコンポーネント作成

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,6 +1,7 @@
 <template>
     <div id="app">
-        <MainView/>
+        <router-view>
+        </router-view>
     </div>
 </template>
 

--- a/src/components/MapDetailCard/index.ts
+++ b/src/components/MapDetailCard/index.ts
@@ -1,0 +1,23 @@
+import { Component, Vue } from 'vue-property-decorator';
+
+@Component
+export default class MapDetailCard extends Vue {
+
+    private name: string = 'Name section';
+    private description: string = 'Desctiption section';
+
+    /**
+     * closeボタンを押すと詳細画面を閉じる
+     */
+    private close() {
+        // pass
+    }
+
+    /**
+     * open mapボタンを押すとMap利用画面に移動
+     */
+    private openMap() {
+        // pass
+    }
+
+}

--- a/src/components/MapDetailCard/index.vue
+++ b/src/components/MapDetailCard/index.vue
@@ -1,0 +1,41 @@
+<template>
+    <v-app>
+        <v-container>
+            <v-row no-gutters>
+                <v-col>
+                    <v-card>
+                        <v-card-title>{{ name }}</v-card-title>
+                        <v-card-text>{{ description }}</v-card-text>
+                        <v-divider></v-divider>
+                        <v-img
+                            height="250"
+                            src="https://picsum.photos/500"
+                        ></v-img>
+                        <v-divider></v-divider>
+                        <v-card-actions>
+                            <v-btn
+                                text
+                                @click="close"
+                            >
+                                Close
+                            </v-btn>
+                            <v-spacer></v-spacer>
+                            <v-btn
+                                text
+                                @click="openMap"
+                            >
+                                Open Map
+                            </v-btn>
+                        </v-card-actions>
+                    </v-card>
+                </v-col>
+            </v-row>
+        </v-container>
+    </v-app>
+</template>
+
+<script lang="ts" src="./index.ts"></script>
+
+<!-- Add "scoped" attribute to limit CSS to this component only -->
+<style scoped>
+</style>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -18,6 +18,11 @@ const routes = [
         // which is lazy-loaded when the route is visited.
         component: () => import(/* webpackChunkName: "about" */ '../views/About.vue'),
     },
+    {
+        path: '/map-detail',
+        name: 'map-detail',
+        component: () => import('../components/MapDetailCard/index.vue'),
+    },
 ];
 
 const router = new VueRouter({


### PR DESCRIPTION
## 実装の概要
#338でリファクタブランチを取り込んでしまい変更がわかりにくくなってしまったため、新しくブランチを作りました。

- 地図選択画面のリストアイテム選択時にポップアップされる画面の雛形作成。
- `/map-detail`にアクセスすると表示されます。
  - 現時点ではサイズ等の調整してません。
  - モック画像は[picsum](https://picsum.photos/)を使用

画面のキャプチャ例
![Screen Shot 0002-06-03 at 4 48 15 PM](https://user-images.githubusercontent.com/37099863/83610288-2d41ab80-a5ba-11ea-97fd-4ca49235d845.png)


close #329 
