### PR TITLE
地図詳細ポップアップの閉じる機能追加

### DIFF
--- a/src/components/MapDetailCard/index.ts
+++ b/src/components/MapDetailCard/index.ts
@@ -5,7 +5,7 @@ export default class MapDetailCard extends Vue {
 
     private name: string = 'Name section';
     private description: string = 'Desctiption section';
-    private dialog: boolean = true;
+    private dialog: boolean = false;
 
     /**
      * closeボタンを押すと詳細画面を閉じる

--- a/src/components/MapDetailCard/index.ts
+++ b/src/components/MapDetailCard/index.ts
@@ -5,12 +5,13 @@ export default class MapDetailCard extends Vue {
 
     private name: string = 'Name section';
     private description: string = 'Desctiption section';
+    private dialog: boolean = true;
 
     /**
      * closeボタンを押すと詳細画面を閉じる
      */
     private close() {
-        // pass
+        this.dialog = false;
     }
 
     /**

--- a/src/components/MapDetailCard/index.vue
+++ b/src/components/MapDetailCard/index.vue
@@ -27,6 +27,7 @@
                             <v-spacer></v-spacer>
                             <v-card-actions>
                                 <v-btn
+                                    id="close"
                                     text
                                     @click="close"
                                 >

--- a/src/components/MapDetailCard/index.vue
+++ b/src/components/MapDetailCard/index.vue
@@ -3,31 +3,45 @@
         <v-container>
             <v-row no-gutters>
                 <v-col>
-                    <v-card>
-                        <v-card-title>{{ name }}</v-card-title>
-                        <v-card-text>{{ description }}</v-card-text>
-                        <v-divider></v-divider>
-                        <v-img
-                            height="250"
-                            src="https://picsum.photos/500"
-                        ></v-img>
-                        <v-divider></v-divider>
-                        <v-card-actions>
-                            <v-btn
-                                text
-                                @click="close"
-                            >
-                                Close
-                            </v-btn>
+                    <v-btn @click.stop="dialog = ! dialog">
+                        Open
+                    </v-btn>
+                    <v-dialog
+                        v-model="dialog"
+                        hide-overlay
+                        max-width="500"
+                    >
+                        <v-card
+                            class="d-flex flex-column"
+                        >
+                            <v-card-title>{{ name }}</v-card-title>
+                            <v-card-text>{{ description }}</v-card-text>
+                            <v-divider></v-divider>
+                            <v-container>
+                                <v-img
+                                    src="https://picsum.photos/500"
+                                    style="height: 40vh;"
+                                ></v-img>
+                            </v-container>
+                            <v-divider></v-divider>
                             <v-spacer></v-spacer>
-                            <v-btn
-                                text
-                                @click="openMap"
-                            >
-                                Open Map
-                            </v-btn>
-                        </v-card-actions>
-                    </v-card>
+                            <v-card-actions>
+                                <v-btn
+                                    text
+                                    @click="close"
+                                >
+                                    Close
+                                </v-btn>
+                                <v-spacer></v-spacer>
+                                <v-btn
+                                    text
+                                    @click="openMap"
+                                >
+                                    Open Map
+                                </v-btn>
+                            </v-card-actions>
+                        </v-card>
+                    </v-dialog>
                 </v-col>
             </v-row>
         </v-container>

--- a/tests/unit/components/MapDetailCard/MapDetailCard.spec.ts
+++ b/tests/unit/components/MapDetailCard/MapDetailCard.spec.ts
@@ -1,0 +1,28 @@
+import { createLocalVue, mount } from '@vue/test-utils';
+import MapDetailCard from '@/components/MapDetailCard/index.vue';
+import Vuetify from 'vuetify';
+
+
+describe('MapDetailCardコンポーネントのテスト', () => {
+    let localVue: any;
+    let wrapper: any;
+    let vuetify: any;
+    beforeEach(() => {
+        vuetify = new Vuetify();
+        localVue = createLocalVue();
+        localVue.use(Vuetify);
+        wrapper = mount( MapDetailCard, {
+            localVue,
+            vuetify,
+            attachToDocument: true,
+        });
+    });
+
+    it('closeボタンを押すとポップアップが閉じる', () => {
+        wrapper.setData({dialog: true});
+        expect(wrapper.vm.dialog).toBe(true);
+        wrapper.find('.v-dialog').find('.v-btn#close').trigger('click');
+        expect(wrapper.vm.dialog).toBe(false);
+    });
+
+});


### PR DESCRIPTION
## 実装の概要
closeボタンを押すとポップアップを閉じます。
`/map-detail`にアクセスして、`open`ボタン（確認用に設置しているため、将来的には取り除きます）を押すと開きます。

## 参考
- [Vuetify ダイアログ](https://vuetifyjs.com/ja/components/dialogs/)
- [Vuetify.js 2.2のDialogコンポーネントについて](https://qiita.com/rubytomato@github/items/d60b92906c2a9ce7f161)


close #333 
