### PR TITLE
mapItem, mapListのテストの作成

### DIFF
--- a/src/components/MapItem/index.ts
+++ b/src/components/MapItem/index.ts
@@ -5,7 +5,8 @@ export default class MapItem extends Vue {
     // 親からマップ名、作成者名を受けとり表示する
     @Prop()
     private mapName!: string;
-    private userName!: string;
+    @Prop()
+    private description!: string;
 
     /**
      * mapItemがクリックされると呼ばれ，mapListを非表示にする．

--- a/src/components/MapItem/index.ts
+++ b/src/components/MapItem/index.ts
@@ -3,10 +3,9 @@ import { Component, Prop, Vue } from 'vue-property-decorator';
 @Component
 export default class MapItem extends Vue {
     // 親からマップ名、作成者名を受けとり表示する
-    @Prop()
-    private mapName!: string;
-    @Prop()
-    private description!: string;
+    @Prop() private mapName!: string;
+    @Prop() private description!: string;
+    private userName!: string;
 
     /**
      * mapItemがクリックされると呼ばれ，mapListを非表示にする．

--- a/src/components/MapItem/index.vue
+++ b/src/components/MapItem/index.vue
@@ -2,13 +2,12 @@
 	<div id="spot-item">
         <v-card
             tile
-            @click="hideMapList();
-                    popupDetailScreen()"
+            @click="hideMapList();"
         >
             <v-list-item two-line>
                 <v-list-item-content>
                     <v-list-item-title class="headline">{{ mapName }}</v-list-item-title>
-                    <v-list-item-subtitle>{{ userName }}</v-list-item-subtitle>
+                    <v-list-item-subtitle>{{ description }}</v-list-item-subtitle>
                 </v-list-item-content>
             </v-list-item>
         </v-card>

--- a/tests/unit/components/MapItem/MapItem.spec.ts
+++ b/tests/unit/components/MapItem/MapItem.spec.ts
@@ -1,7 +1,6 @@
 import { createLocalVue, mount } from '@vue/test-utils';
 import Vuex from 'vuex';
 import Vuetify from 'vuetify';
-import { mapViewGetters, mapViewMutations } from '@/store';
 import MapItem from '@/components/MapItem/index.vue';
 
 describe('MapItemコンポーネントのテスト', () => {
@@ -19,12 +18,13 @@ describe('MapItemコンポーネントのテスト', () => {
             attachToDocument: true,
             propsData: {
                 mapName: 'kyudai',
-                userName: 'unknown',
+                description: 'description of kyudai',
             },
         });
     });
 
-    it.skip('', () => {
-        // do nothing
+    it('親スポットがない場合，スポットの名前と距離が表示される', () => {
+        expect(wrapper.find('.v-list-item__title').text()).toBe('kyudai');
+        expect(wrapper.find('.v-list-item__subtitle').text()).toBe('description of kyudai');
     });
 });

--- a/tests/unit/components/MapList/MapList.spec.ts
+++ b/tests/unit/components/MapList/MapList.spec.ts
@@ -1,9 +1,6 @@
 import { shallowMount } from '@vue/test-utils';
 import MapList from '@/components/MapList/index.vue';
-import { RawMap } from '@/store/types';
 
-// 現状MapListはEmitの作業しか行っておらずEmitのテストはMapSearchにて行っている為,テストはありません
-// その後の機能追加にてテストが発生する可能性がある
 describe('MapListコンポーネントのテスト', () => {
     let wrapper: any;
 
@@ -17,7 +14,7 @@ describe('MapListコンポーネントのテスト', () => {
         wrapper.destroy();
     });
 
-    it.skip('', () => {
-        // do nothing
+    it.skip('現状MapListはEmitの作業しか行っておらずEmitのテストはMapSearchにて行っている為,テストはありません', () => {
+        // 機能追加によりテストが発生する可能性があり
     });
 });


### PR DESCRIPTION
## 実装の概要
 - mapItem, mapListのテストがスキップのままだと好ましくないためテストの作成

## 備考
 - mapListは現状emitしか行ってしかいない状態なので機能追加までテストはありません

close イシュー番号（例：close #45）
close #355
