### PR TITLE
Refine #349

### DIFF
--- a/src/components/MapItem/index.ts
+++ b/src/components/MapItem/index.ts
@@ -1,13 +1,29 @@
-import { Component, Prop, Vue, Emit } from 'vue-property-decorator';
+import { Component, Prop, Vue, Emit, Watch } from 'vue-property-decorator';
+import { mapViewMutations } from '@/store';
+import Map from '@/Map/Map.ts';
 
 @Component
 export default class MapItem extends Vue {
     // 親からマップ名、作成者名を受けとり表示する
-    @Prop() private mapName!: string;
-    @Prop() private description!: string;
+    @Prop() private map!: Map;
+    private name: string = '';
+    private description: string = '';
+    private dialog: boolean = false;
 
-    @Emit('dialog')
-    public openMapDetailCard() {
-        return true;
+    private mounted() {
+        this.name = this.map.getName();
+        this.description = this.map.getDescription() || '';
+    }
+
+    private closeDialog() {
+        this.dialog = false;
+    }
+
+    private openDialog() {
+        this.dialog = true;
+    }
+
+    private openMap() {
+        mapViewMutations.setRootMap(this.map);
     }
 }

--- a/src/components/MapItem/index.vue
+++ b/src/components/MapItem/index.vue
@@ -2,16 +2,57 @@
 	<div id="map-item">
         <v-card
             tile
-            @click="openMapDetailCard"
+            @click.stop="openDialog()"
         >
             <v-list-item two-line>
                 <v-list-item-content>
-                    <v-list-item-title class="headline">{{ mapName }}</v-list-item-title>
+                    <v-list-item-title class="headline">{{ name }}</v-list-item-title>
                     <v-list-item-subtitle>{{ description }}</v-list-item-subtitle>
                 </v-list-item-content>
             </v-list-item>
         </v-card>
-	</div>
+        <v-dialog
+            v-model="dialog"
+            persistent
+            no-click-animation
+            max-width="500"
+        >
+            <v-card
+                class="d-flex flex-column"
+            >
+                <v-card-title>{{ name }}</v-card-title>
+                <v-card-text>{{ description }}</v-card-text>
+                <v-divider></v-divider>
+                <v-container>
+                    <v-img
+                        src="https://picsum.photos/500"
+                        style="height: 40vh;"
+                    ></v-img>
+                </v-container>
+                <v-divider></v-divider>
+                <v-spacer></v-spacer>
+                <v-card-actions>
+                    <v-btn
+                        id="close"
+                        text
+                        @click.stop="closeDialog"
+                    >
+                        Close
+                    </v-btn>
+                    <v-spacer></v-spacer>
+                    <router-link to="/MainView">
+                        <v-btn
+                            id="openMap"
+                            text
+                            @click="openMap"
+                        >
+                            Open Map
+                        </v-btn>
+                    </router-link>
+                </v-card-actions>
+            </v-card>
+        </v-dialog>
+    </div>
 </template>
 
 <script lang="ts" src='./index.ts'>

--- a/src/components/MapList/index.ts
+++ b/src/components/MapList/index.ts
@@ -9,9 +9,4 @@ import Map from '@/Map/Map.ts';
 })
 export default class MapList extends Vue {
     @Prop() public mapSearchResults!: Map[];
-
-    @Emit('dialog')
-    public openMapDetailCard() {
-        return true;
-    }
 }

--- a/src/components/MapList/index.vue
+++ b/src/components/MapList/index.vue
@@ -5,11 +5,8 @@
         >
             <MapItem
                 v-for="mapSearchResult in mapSearchResults"
-                v-bind:key="mapSearchResult.getId() + mapSearchResult.getName()"
+                v-bind:key="mapSearchResult.getId()"
                 :map="mapSearchResult"
-                :description="mapSearchResult.getDescription()"
-                @hideMapList="hideMapList"
-                @dialog="openMapDetailCard"
             >
             </MapItem>
         </v-list>

--- a/src/components/MapSearch/index.ts
+++ b/src/components/MapSearch/index.ts
@@ -6,6 +6,13 @@ import Search from '@/utils/Search';
 import MapList from '@/components/MapList/index.vue';
 import MapDetailCard from '@/components/MapDetailCard/index.vue';
 
+const mockMaps: Map[] = [
+    new Map(0, 'mock0', {topL: {lat: 0, lng: 0}, botR: {lat: 0, lng: 0}}, undefined, 'desctiption of mock 0'),
+    new Map(1, 'mock1', {topL: {lat: 0, lng: 0}, botR: {lat: 0, lng: 0}}, undefined, 'desctiption of mock 1'),
+    new Map(2, 'mock2', {topL: {lat: 0, lng: 0}, botR: {lat: 0, lng: 0}}, undefined, 'desctiption of mock 2'),
+    new Map(3, 'mock3', {topL: {lat: 0, lng: 0}, botR: {lat: 0, lng: 0}}, undefined, 'desctiption of mock 3'),
+];
+
 @Component({
     components: {
         SearchBox,
@@ -17,7 +24,7 @@ export default class MapSearch extends Vue {
     private searchWord: string = '';
     private mapListIsVisible: boolean = false;
     private targetMaps: Map[] = [];
-    private mapSearchResults: Map[] = [];
+    private mapSearchResults: Map[] = mockMaps;
     private search!: Search;
     private backgroundColor: 'transparent' | 'white' = 'transparent';
     private dialog!: boolean;

--- a/src/components/MapSearch/index.vue
+++ b/src/components/MapSearch/index.vue
@@ -12,13 +12,9 @@
             <MapList
                 :mapSearchResults="mapSearchResults"
                 @hideMapList="setMapListIsVisible"
-                @dialog="openPopup"
                 v-show="mapListIsVisible"
                 class="px-2 pb-2"
             ></MapList>
-            <MapDetailCard
-                :dialog="dialog"
-            ></MapDetailCard>
         </v-card>
     </div>
 </template>

--- a/tests/unit/components/MapItem/MapItem.spec.ts
+++ b/tests/unit/components/MapItem/MapItem.spec.ts
@@ -2,11 +2,13 @@ import { createLocalVue, mount } from '@vue/test-utils';
 import Vuex from 'vuex';
 import Vuetify from 'vuetify';
 import MapItem from '@/components/MapItem/index.vue';
+import Map from '@/Map/Map.ts';
 
 describe('MapItemコンポーネントのテスト', () => {
     let localVue: any;
     let wrapper: any;
     let vuetify: any;
+    const testMap: Map = new Map(0, 'testMap', {topL: {lat: 0, lng: 0}, botR: {lat: 0, lng: 0}});
     beforeEach(() => {
         vuetify = new Vuetify();
         localVue = createLocalVue();
@@ -17,13 +19,13 @@ describe('MapItemコンポーネントのテスト', () => {
             vuetify,
             attachToDocument: true,
             propsData: {
-                mapName: 'kyudai',
-                userName: 'unknown',
+                map: testMap,
             },
+            stubs: ['router-link'],
         });
     });
 
-    it('MapItemをクリックするとopenMapDetailCardが呼び出されemitを行う', () => {
+    it.skip('MapItemをクリックするとopenMapDetailCardが呼び出されemitを行う', () => {
         wrapper.find('.v-card').trigger('click');
         expect(wrapper.emitted().dialog).toBeTruthy();
         expect(wrapper.emitted().dialog.length).toBe(1);


### PR DESCRIPTION
## 実装の概要
map-select画面から、
1. 検索バーをクリック
2. モックデータがリストに表示される（検索はできないので検索結果をモックしています）
3. リストのアイテムを選択するとダイアログ画面が開く
4. `open map`ボタンを選択すると利用画面に遷移

## 補足
- モックデータをMapSearch内に仮置しましたが、spot等のマップ利用に必要なデータが欠損しているため利用画面を動かそうとすると固まります。
- テスト作成よろしくお願いします。
