### PR TITLE
地図作成画面のUI改善

### DIFF
--- a/src/components/CreationMapView/ShapeEditor.ts
+++ b/src/components/CreationMapView/ShapeEditor.ts
@@ -132,7 +132,7 @@ export default class ShapeEditor {
      * マップ上にCircleMarkerを用いた点と，前の点から続くPolyLineを用いた線を描画する
      * @param e 終点追加後に完成したShapeを引数に取るコールバック関数をメンバにもつ
      */
-    public addPoint(e: { latlng: L.LatLng, afterAddEndPoint: (shape: Shape) => void }): void {
+    public addPoint(e: { latlng: L.LatLng, afterAddEndPoint: (shape: Shape) => void, afterSecondClick: () => void }): void {
         this.coordinates.push(e.latlng as Coordinate);
 
         const circleMarker: L.CircleMarker = L.circleMarker(e.latlng, {
@@ -143,6 +143,9 @@ export default class ShapeEditor {
                 const shape: Shape = this.createShape();
                 e.afterAddEndPoint(shape);
             });
+        }
+        if (this.circleMarkers.length == 1) {
+            e.afterSecondClick();
         }
         circleMarker.addTo(this.lMap);
         this.circleMarkers.push(circleMarker);

--- a/src/components/CreationMapView/ShapeEditor.ts
+++ b/src/components/CreationMapView/ShapeEditor.ts
@@ -132,7 +132,9 @@ export default class ShapeEditor {
      * マップ上にCircleMarkerを用いた点と，前の点から続くPolyLineを用いた線を描画する
      * @param e 終点追加後に完成したShapeを引数に取るコールバック関数をメンバにもつ
      */
-    public addPoint(e: { latlng: L.LatLng, afterAddEndPoint: (shape: Shape) => void, afterSecondClick: () => void }): void {
+    public addPoint(e: {
+        latlng: L.LatLng, afterAddEndPoint: (shape: Shape) => void, afterSecondClick: () => void,
+    }): void {
         this.coordinates.push(e.latlng as Coordinate);
 
         const circleMarker: L.CircleMarker = L.circleMarker(e.latlng, {
@@ -143,26 +145,32 @@ export default class ShapeEditor {
                 const shape: Shape = this.createShape();
                 e.afterAddEndPoint(shape);
             });
+            circleMarker.on('mouseover', (event) => {
+                if (this.circleMarkers.length > 1) {
+                    circleMarker.setStyle({fillColor: '#CF944E'});
+                }
+            });
+            circleMarker.on('mouseout', (event) => {
+                if (this.circleMarkers.length > 1) {
+                    circleMarker.setStyle({fillColor: 'white'});
+                }
+            });
         }
-        if (this.circleMarkers.length == 1) {
+        if (this.circleMarkers.length === 1) {
             e.afterSecondClick();
         }
+        this.lMap.on('mousemove', (event: L.LeafletMouseEvent) => {
+            const coordinates = this.coordinates.concat([event.latlng]);
+            this.displayRouteLine(coordinates);
+        });
         circleMarker.addTo(this.lMap);
         this.circleMarkers.push(circleMarker);
 
         if (this.coordinates.length > 1) {
-            if (this.routeLine !== null) {
-                this.routeLine.remove();
-                this.controlLayer.removeLayer(this.routeLine);
-            }
-            this.routeLine = L.polyline(this.coordinates, {
-                color: '#555555',
-                weight: 5,
-                opacity: 0.7,
-            });
-            this.routeLine.addTo(this.lMap);
+            this.displayRouteLine(this.coordinates);
         }
     }
+
 
     /**
      * 指定されたスポットのポリゴンを表示する
@@ -217,6 +225,20 @@ export default class ShapeEditor {
         this.circleMarkers.forEach((marker) => marker.remove());
         this.circleMarkers = [];
         this.coordinates = [];
+        this.lMap.off('mousemove');
+    }
+
+    private displayRouteLine(coordinates: Coordinate[]) {
+        if (this.routeLine !== null) {
+            this.routeLine.remove();
+            this.controlLayer.removeLayer(this.routeLine);
+        }
+        this.routeLine = L.polyline(coordinates, {
+            color: '#555555',
+            weight: 5,
+            opacity: 0.7,
+        });
+        this.routeLine.addTo(this.lMap);
     }
 
     /**

--- a/src/components/CreationMapView/index.ts
+++ b/src/components/CreationMapView/index.ts
@@ -277,10 +277,12 @@ export default class CreationMapView extends Vue {
             this.leafletContainer.style.cursor = 'crosshair';
         }
         this.shapeEditButtonIsVisible = true;
-        this.onMapClick = (e: { latlng: L.LatLng, afterSecondClick: () => void, afterAddEndPoint: (shape: Shape) => void }) => {
+        this.onMapClick = (e: {
+            latlng: L.LatLng, afterSecondClick: () => void, afterAddEndPoint: (shape: Shape) => void,
+        }) => {
             e.afterSecondClick = () => {
                 this.messageWhileShapeEditing = '始点をクリックして図形を閉じる';
-            }
+            };
             /**
              * ラインの終点が描画された後に呼び出される関数
              * ポリゴンの描画や後処理を行う

--- a/src/components/CreationMapView/index.ts
+++ b/src/components/CreationMapView/index.ts
@@ -32,11 +32,12 @@ export default class CreationMapView extends Vue {
     // 次にクリックしたときに設置されるスポットタイプ
     private spotTypeToAddNext: SpotType = 'default';
     private mapAreaSelectionInfoIsVisible: boolean = true;
+    private messageWhileShapeEditing: 'クリックしてスポットの範囲を描画' | '始点をクリックして図形を閉じる' = 'クリックしてスポットの範囲を描画';
     private outOfMapRangeWarningIsVisible: boolean = false;
     private shapeEditButtonIsVisible: boolean = false;
     private spotButtonInEditorToolBarIsVisible: boolean = false;
     private flyToMapBoundsButtonIsVisible: boolean = false;
-    private disabledShapeEditButtonInSpotEditor: boolean = false;
+    private whileShapeEditing: boolean = false;
     private spotEditorIsVisible: boolean = false;
     private focusedSpot: Spot | null = null;
     private spotMarkers: SpotMarker[] = [];
@@ -271,12 +272,15 @@ export default class CreationMapView extends Vue {
      * マップクリック時に実行される関数を，形状描画メソッドにする
      */
     private setAddPointMethodOnMapClick(): void {
-        this.disabledShapeEditButtonInSpotEditor = true;
+        this.whileShapeEditing = true;
         if (this.leafletContainer !== null) {
             this.leafletContainer.style.cursor = 'crosshair';
         }
         this.shapeEditButtonIsVisible = true;
-        this.onMapClick = (e: { latlng: L.LatLng, afterAddEndPoint: (shape: Shape) => void }) => {
+        this.onMapClick = (e: { latlng: L.LatLng, afterSecondClick: () => void, afterAddEndPoint: (shape: Shape) => void }) => {
+            e.afterSecondClick = () => {
+                this.messageWhileShapeEditing = '始点をクリックして図形を閉じる';
+            }
             /**
              * ラインの終点が描画された後に呼び出される関数
              * ポリゴンの描画や後処理を行う
@@ -300,7 +304,8 @@ export default class CreationMapView extends Vue {
                  */
                 this.onMapClick = (event: any) => undefined;
                 setTimeout(this.setDefaultMethodOnMapClick, 500);
-                this.disabledShapeEditButtonInSpotEditor = false;
+                this.whileShapeEditing = false;
+                this.messageWhileShapeEditing = 'クリックしてスポットの範囲を描画';
             };
             this.shapeEditor.addPoint(e);
         };
@@ -309,10 +314,10 @@ export default class CreationMapView extends Vue {
     /**
      * 編集ツールバーコンボーケントでモードが切り替わった際に実行される
      */
-    private onSwitchModeOfToolBar() {
+    private cancelShapeEditMode() {
         this.shapeEditButtonIsVisible = false;
         this.shapeEditor.removeShapeEditLine();
-        this.disabledShapeEditButtonInSpotEditor = false;
+        this.whileShapeEditing = false;
     }
 
     /**
@@ -489,3 +494,5 @@ export default class CreationMapView extends Vue {
         this.focusedSpot!.deleteDetailMap(id);
     }
 }
+
+

--- a/src/components/CreationMapView/index.ts
+++ b/src/components/CreationMapView/index.ts
@@ -32,7 +32,7 @@ export default class CreationMapView extends Vue {
     // 次にクリックしたときに設置されるスポットタイプ
     private spotTypeToAddNext: SpotType = 'default';
     private mapAreaSelectionInfoIsVisible: boolean = true;
-    private messageWhileShapeEditing: 'クリックしてスポットの範囲を描画' | '始点をクリックして図形を閉じる' = 'クリックしてスポットの範囲を描画';
+    private messageWhileShapeEditing: 'クリックしてスポットの範囲を描画' | '始点をクリックして範囲選択を終了する' = 'クリックしてスポットの範囲を描画';
     private outOfMapRangeWarningIsVisible: boolean = false;
     private shapeEditButtonIsVisible: boolean = false;
     private spotButtonInEditorToolBarIsVisible: boolean = false;
@@ -281,7 +281,7 @@ export default class CreationMapView extends Vue {
             latlng: L.LatLng, afterSecondClick: () => void, afterAddEndPoint: (shape: Shape) => void,
         }) => {
             e.afterSecondClick = () => {
-                this.messageWhileShapeEditing = '始点をクリックして図形を閉じる';
+                this.messageWhileShapeEditing = '始点をクリックして範囲選択を終了する';
             };
             /**
              * ラインの終点が描画された後に呼び出される関数
@@ -314,7 +314,7 @@ export default class CreationMapView extends Vue {
     }
 
     /**
-     * 編集ツールバーコンボーケントでモードが切り替わった際に実行される
+     * 編集ツールバーコンボーネントでモードが切り替わった際に実行される
      */
     private cancelShapeEditMode() {
         this.shapeEditButtonIsVisible = false;

--- a/src/components/CreationMapView/index.vue
+++ b/src/components/CreationMapView/index.vue
@@ -30,6 +30,15 @@
                   作成するマップの範囲を選択してください
                 </v-alert>
                 <v-alert
+                  type="info"
+                  border="top"
+                  colored-border
+                  color="#CF944E"
+                  v-show="whileShapeEditing"
+                >
+                  {{ messageWhileShapeEditing }}
+                </v-alert>
+                <v-alert
                   type="warning"
                   border="top"
                   colored-border
@@ -117,9 +126,10 @@
                   <SpotEditor
                     :isVisible="focusedSpot !== null"
                     @spotInput="updateFocusedMarkerName"
-                    :disabledShapeEditButton="disabledShapeEditButtonInSpotEditor"
+                    :whileShapeEditing="whileShapeEditing"
                     :spot="focusedSpot"
                     @clickAddShapeButton="setAddPointMethodOnMapClick"
+                    @clickAddShapeCancelButton="cancelShapeEditMode"
                     @delete="deleteFocusedSpot"
                     @add="addDetailMap"
                     @edit="editDetailMap"
@@ -166,7 +176,15 @@
                   icon
                   @click="dialog = true; setMapToStore()"
                 >
-                  <v-icon>cloud_upload</v-icon>
+                <v-tooltip right>
+                  <template v-slot:activator="{ on, attrs }">
+                  <v-icon
+                    v-bind="attrs"
+                    v-on="on"
+                  >cloud_upload</v-icon>
+                </template>
+                <span>アップロード</span>
+              </v-tooltip>
                 </v-btn>
               </v-app-bar>
             </v-col>
@@ -181,7 +199,7 @@
                   @clickZoomOut="zoomOut"
                   @clickSelect="setDefaultMethodOnMapClick"
                   @clickSpot="setAddSpotMethodOnMapClick"
-                  @switchMode="onSwitchModeOfToolBar"
+                  @switchMode="cancelShapeEditMode"
                   :spotButtonIsVisible="spotButtonInEditorToolBarIsVisible"
                   :shapeEditButtonIsVisible="shapeEditButtonIsVisible"
                 />

--- a/src/components/EditorToolBar/index.ts
+++ b/src/components/EditorToolBar/index.ts
@@ -6,10 +6,10 @@ export default class EditorToolBar extends Vue {
     // 色は仮
     private selectedColor: string = '#264F45';
     private defaultColor: string = '#76978F';
-    private buttons: Array<{ action: Action, icon: string, color: string }> = [
-        {action: 'zoomIn',  icon: 'zoom_in',  color: this.defaultColor},
-        {action: 'zoomOut', icon: 'zoom_out', color: this.defaultColor},
-        {action: 'move',    icon: 'pan_tool', color: this.selectedColor},
+    private buttons: Array<{ action: Action, icon: string, color: string, tooltip: string }> = [
+        {action: 'zoomIn',  icon: 'zoom_in',  color: this.defaultColor, tooltip: '拡大'},
+        {action: 'zoomOut', icon: 'zoom_out', color: this.defaultColor, tooltip: '縮小'},
+        {action: 'move',    icon: 'pan_tool', color: this.selectedColor, tooltip: '移動'},
     ];
     private spotButtonColor: string = this.defaultColor;
     private spotIconMaps: Array<{iconName: string, spotType: SpotType}> = [

--- a/src/components/EditorToolBar/index.vue
+++ b/src/components/EditorToolBar/index.vue
@@ -14,36 +14,54 @@
               :color="button.color"
               @click="onButtonClick(button.action)"
             >
-              <v-icon icon>{{ button.icon }}</v-icon>
+              <v-tooltip left>
+                <template v-slot:activator="{ on, attrs }">
+                  <v-icon
+                    icon
+                    v-bind="attrs"
+                    v-on="on"
+                  >
+                    {{ button.icon }}
+                  </v-icon>
+                </template>
+                <span>{{ button.tooltip }}</span>
+              </v-tooltip>
             </v-btn>
-            <v-speed-dial
-              direction="left"
-              v-model="fabVisible"
-            >
-              <template v-slot:activator>
-                <v-btn
-                  :color="spotButtonColor"
+            <v-tooltip left>
+              <template v-slot:activator="{ on, attrs }">
+                <v-speed-dial
+                  direction="left"
                   v-model="fabVisible"
-                  v-show="spotButtonIsVisible"
-                  icon
                 >
-                  <v-icon v-if="fabVisible">close</v-icon>
-                  <v-icon v-if="!fabVisible && selectedMode != 'spot'">add_location</v-icon>
-                  <v-icon v-if="!fabVisible && selectedMode == 'spot'">{{ selectedSpotIcon }}</v-icon>
-                </v-btn>
+                  <template v-slot:activator>
+                    <v-btn
+                      :color="spotButtonColor"
+                      v-model="fabVisible"
+                      v-show="spotButtonIsVisible"
+                      v-bind="attrs"
+                      v-on="on"
+                      icon
+                    >
+                      <v-icon v-if="fabVisible">close</v-icon>
+                      <v-icon v-if="!fabVisible && selectedMode != 'spot'">add_location</v-icon>
+                      <v-icon v-if="!fabVisible && selectedMode == 'spot'">{{ selectedSpotIcon }}</v-icon>
+                    </v-btn>
+                  </template>
+                  <v-btn 
+                    color="#3F8373"
+                    v-for="(spotIconMap, index) in spotIconMaps"
+                    v-bind:key="index"
+                    fab
+                    small
+                    dark
+                    @click="setSelectedSpotIcon(spotIconMap.iconName); onButtonClick('spot')"
+                  >
+                    <v-icon>{{ spotIconMap.iconName }}</v-icon>
+                  </v-btn>
+                </v-speed-dial>
               </template>
-              <v-btn 
-                color="#3F8373"
-                v-for="(spotIconMap, index) in spotIconMaps"
-                v-bind:key="index"
-                fab
-                small
-                dark
-                @click="setSelectedSpotIcon(spotIconMap.iconName); onButtonClick('spot')"
-              >
-                <v-icon>{{ spotIconMap.iconName }}</v-icon>
-              </v-btn>
-            </v-speed-dial>
+              <span>スポット設置</span>
+            </v-tooltip>
             <v-btn
               icon
               class="mt-1"

--- a/src/components/EditorToolBar/index.vue
+++ b/src/components/EditorToolBar/index.vue
@@ -67,7 +67,6 @@
               class="mt-1"
               v-show="shapeEditButtonIsVisible"
               :color="shapeEditButton.color"
-              @click="onButtonClick(shapeEditButton.action)"
             >
               <v-icon icon>{{ shapeEditButton.icon }}</v-icon>
             </v-btn>

--- a/src/components/SpotEditor/index.ts
+++ b/src/components/SpotEditor/index.ts
@@ -16,9 +16,10 @@ export default class SpotEditor extends Vue {
     @Prop()
     public isVisible!: boolean;
     @Prop()
-    public disabledShapeEditButton!: boolean;
-    public attachment: [{name: string, url: string}] = [{name: '', url: ''}];
-    public dialog: boolean = false;
+    public whileShapeEditing!: boolean;
+    private shapeAddButtonName: 'スポットの範囲' | 'キャンセル' = 'スポットの範囲';
+    private attachment: [{name: string, url: string}] = [{name: '', url: ''}];
+    private dialog: boolean = false;
 
     /**
      * DetailMapManageListから詳細マップ追加のイベントが発火されると呼び出され、
@@ -60,6 +61,23 @@ export default class SpotEditor extends Vue {
             return 'add_circle';
         } else {
             return 'edit';
+        }
+    }
+
+    @Watch('whileShapeEditing')
+    private switchShapeAddButtonName(): void {
+        if (this.whileShapeEditing) {
+            this.shapeAddButtonName = 'キャンセル';
+        } else {
+            this.shapeAddButtonName = 'スポットの範囲';
+        }
+    }
+
+    private onClickShapeAddButton(): void {
+        if (this.whileShapeEditing) {
+            this.$emit('clickAddShapeCancelButton');
+        } else {
+            this.$emit('clickAddShapeButton');
         }
     }
 

--- a/src/components/SpotEditor/index.ts
+++ b/src/components/SpotEditor/index.ts
@@ -17,7 +17,7 @@ export default class SpotEditor extends Vue {
     public isVisible!: boolean;
     @Prop()
     public whileShapeEditing!: boolean;
-    private shapeAddButtonName: 'スポットの範囲' | 'キャンセル' = 'スポットの範囲';
+    private shapeAddButtonName: '範囲選択' | 'キャンセル' = '範囲選択';
     private attachment: [{name: string, url: string}] = [{name: '', url: ''}];
     private dialog: boolean = false;
 
@@ -69,7 +69,7 @@ export default class SpotEditor extends Vue {
         if (this.whileShapeEditing) {
             this.shapeAddButtonName = 'キャンセル';
         } else {
-            this.shapeAddButtonName = 'スポットの範囲';
+            this.shapeAddButtonName = '範囲選択';
         }
     }
 

--- a/src/components/SpotEditor/index.vue
+++ b/src/components/SpotEditor/index.vue
@@ -34,11 +34,10 @@
           class="ma-1"
           color="#3fa590"
           outlined
-          :disabled="disabledShapeEditButton"
-          @click="$emit('clickAddShapeButton')"
+          @click="onClickShapeAddButton()"
         >
-            <span>形状</span>
-            <v-icon right>{{ shapeAddButtonIcon() }}</v-icon>
+          <span>{{ shapeAddButtonName }}</span>
+          <v-icon right v-show="!whileShapeEditing">{{ shapeAddButtonIcon() }}</v-icon>
         </v-btn>
         <v-spacer></v-spacer>
         <v-btn


### PR DESCRIPTION
## 実装の概要
- 編集ツールバーとアップロードボタンにツールチップ追加
- 形状追加ボタンの表示名を"スポットの範囲"に変更
- 形状描画時に流れの説明Infoを表示するように(二段階)
- 形状描画時に，カーソル移動中も常にラインを表示するように
    - この変化に伴ってカーソルの種類の変更ができなくなったため，始点をホバーしたときは始点のマーカーの色が変わるようにした 



