### PR TITLE
Move detailmap control to treeview

### DIFF
--- a/src/components/CreationMapView/index.ts
+++ b/src/components/CreationMapView/index.ts
@@ -133,7 +133,6 @@ export default class CreationMapView extends Vue {
             name: map.getName(),
             type: 'Map',
             children: map.getSpots().map((s: Spot) => this.spotToJson(s)),
-            hovered: false,
         };
     }
 
@@ -148,7 +147,6 @@ export default class CreationMapView extends Vue {
             type: 'Spot',
             iconName: spot.getIconName(),
             children: spot.getDetailMaps().map((m: Map) => this.mapToJson(m)),
-            hovered: false,
         };
     }
 

--- a/src/components/CreationMapView/index.ts
+++ b/src/components/CreationMapView/index.ts
@@ -13,7 +13,6 @@ import { cloneDeep } from 'lodash';
 import MapInformationDialog from '@/components/MapInformationDialog/index.vue';
 import { getBounds, isPointInPolygon } from 'geolib';
 import TreeView from '@/components/TreeView/index.vue';
-import SpotMarker from '@/components/MapView/Marker/SpotMarker';
 
 @Component({
     components: {

--- a/src/components/CreationMapView/index.ts
+++ b/src/components/CreationMapView/index.ts
@@ -374,7 +374,7 @@ export default class CreationMapView extends Vue {
 
         const newDetailMap: Map = new Map(
             nextMapId,
-            'testDetailMap' + String(nextMapId),
+            '詳細マップ' + String(nextMapId),
             mapBounds,
             undefined,
         );

--- a/src/components/CreationMapView/index.ts
+++ b/src/components/CreationMapView/index.ts
@@ -12,12 +12,14 @@ import ShapeEditor from './ShapeEditor';
 import { cloneDeep } from 'lodash';
 import MapInformationDialog from '@/components/MapInformationDialog/index.vue';
 import { getBounds, isPointInPolygon } from 'geolib';
+import TreeView from '@/components/TreeView/index.vue';
 
 @Component({
     components: {
         EditorToolBar,
         SpotEditor,
         MapInformationDialog,
+        TreeView,
     },
 })
 export default class CreationMapView extends Vue {
@@ -49,7 +51,6 @@ export default class CreationMapView extends Vue {
 
     // 作成中のマップtreeviewで利用
     private items: any = [];
-    private tree = [];
     private mapFileTreeDialog: boolean = false;
     private drawer: boolean = false;
 

--- a/src/components/CreationMapView/index.ts
+++ b/src/components/CreationMapView/index.ts
@@ -497,7 +497,7 @@ export default class CreationMapView extends Vue {
      * @param map 複製対象のマップ
      */
     private duplicateDetailMap(mapId: number) {
-        const targetMap: Map | null = this.map.findMap(mapId);
+        const targetMap: Map | null = this.rootMap.findMap(mapId);
         if (targetMap === null) {
             throw new Error('The selected Map does not exist.');
         }
@@ -537,7 +537,7 @@ export default class CreationMapView extends Vue {
      * @param id 削除対象マップのid
      */
     private deleteDetailMap(id: number) {
-        const targetMap: Map | null = this.map.findMap(id);
+        const targetMap: Map | null = this.rootMap.findMap(id);
         const parentSpot: Spot | undefined = targetMap?.getParentSpot();
         if (parentSpot === undefined) {
             throw new Error('The selected Map does not have parent spot.');

--- a/src/components/CreationMapView/index.ts
+++ b/src/components/CreationMapView/index.ts
@@ -13,6 +13,7 @@ import { cloneDeep } from 'lodash';
 import MapInformationDialog from '@/components/MapInformationDialog/index.vue';
 import { getBounds, isPointInPolygon } from 'geolib';
 import TreeView from '@/components/TreeView/index.vue';
+import SpotMarker from '@/components/MapView/Marker/SpotMarker';
 
 @Component({
     components: {
@@ -439,6 +440,13 @@ export default class CreationMapView extends Vue {
         }
         this.editDetailMap(parentMap);
         this.focusedSpot = spotToEdit;
+    }
+
+    @Watch('focusedSpot')
+    private updateMarker() {
+        const targetMarker: SpotMarker | undefined = this.spotMarkers
+            .find((spotMarker: SpotMarker) => spotMarker.getSpot().getId() === this.focusedSpot?.getId());
+        targetMarker?.setSelected(true);
     }
 
     /**

--- a/src/components/CreationMapView/index.ts
+++ b/src/components/CreationMapView/index.ts
@@ -133,6 +133,7 @@ export default class CreationMapView extends Vue {
             name: map.getName(),
             type: 'Map',
             children: map.getSpots().map((s: Spot) => this.spotToJson(s)),
+            hovered: false,
         };
     }
 
@@ -146,6 +147,7 @@ export default class CreationMapView extends Vue {
             name: spot.getName(),
             type: 'Spot',
             children: spot.getDetailMaps().map((m: Map) => this.mapToJson(m)),
+            hovered: false,
         };
     }
 

--- a/src/components/CreationMapView/index.vue
+++ b/src/components/CreationMapView/index.vue
@@ -67,6 +67,8 @@
                     :items="items"
                     @setMapToEdit="setMapToEdit"
                     @setSpotToEdit="setSpotToEdit"
+                    @dup="duplicateDetailMap"
+                    @del="deleteDetailMap"
                   />
                 </v-card>
 
@@ -92,8 +94,6 @@
                     @delete="deleteFocusedSpot"
                     @add="addDetailMap"
                     @edit="editDetailMap"
-                    @dup="duplicateDetailMap"
-                    @del="deleteDetailMap"
                   />
                 </v-card>
               </v-navigation-drawer>

--- a/src/components/CreationMapView/index.vue
+++ b/src/components/CreationMapView/index.vue
@@ -63,42 +63,11 @@
                     Tree View
                   </v-card-text>
                   </v-card>
-                  <v-treeview
-                    hoverable
-                    open-all
-                    v-model="tree"
+                  <TreeView
                     :items="items"
-                    item-key="name"
-                    dense
-                  >
-                  <template
-                    v-slot:prepend="{ item }"
-                  >
-                    <div
-                      @click="item.type === 'Map'
-                        ? setMapToEdit(item.id) 
-                        : setSpotToEdit(item.id)"
-                    >
-                    <v-btn
-                      icon
-                      v-if="item.type==='Map'"
-                    >
-                      <v-icon>
-                        map
-                      </v-icon>
-                    </v-btn>
-                    <v-btn
-                      icon
-                      v-if="item.type==='Spot'"
-                    >
-                      <v-icon left
-                      >
-                        place
-                      </v-icon>
-                    </v-btn>
-                    </div>
-                  </template>
-                  </v-treeview>
+                    @setMapToEdit="setMapToEdit"
+                    @setSpotToEdit="setSpotToEdit"
+                  />
                 </v-card>
 
                 <v-card 

--- a/src/components/SpotEditor/index.vue
+++ b/src/components/SpotEditor/index.vue
@@ -75,14 +75,6 @@
         ></delete-confirmation-dialog>
       </v-dialog>
       </v-container>
-      <detail-map-manage-list
-        :detailMaps="spot.getDetailMaps()"
-        @add="addDetailMap"
-        @edit="editDetailMap"
-        @dup="duplicateDetailMap"
-        @del="deleteDetailMap"
-      >
-      </detail-map-manage-list>
     </v-card>
   </div>
 </template>

--- a/src/components/TreeView/index.ts
+++ b/src/components/TreeView/index.ts
@@ -1,10 +1,19 @@
 import { Component, Emit, Vue, Prop } from 'vue-property-decorator';
+import DeleteConfirmationDialog from '@/components/DeleteConfirmationDialog/index.vue';
+import Map from '@/Map/Map';
 
-@Component
+@Component({
+    components: {
+        DeleteConfirmationDialog,
+    },
+})
 export default class TreeView extends Vue {
     @Prop()
     private items: any;
     private tree = [];
+    private dialog: boolean = false;
+    private selectedMapId!: number;
+    private selectedMapName: string = '';
 
     @Emit('setMapToEdit')
     private sendMapToEdit(id: number) {
@@ -14,5 +23,42 @@ export default class TreeView extends Vue {
     @Emit('setSpotToEdit')
     private sendSpotToEdit(id: number) {
         return id;
+    }
+
+    private getSpotIconName(spotItem: any) {
+        return spotItem.iconName;
+    }
+
+    /**
+     * 削除ボタンを押すと呼び出され、削除確認ダイアログを表示する。
+     * @param mapItem 削除対象の詳細マップ
+     */
+    private confirmMapDeletion(mapItem: any) {
+        this.dialog = true;
+        this.selectedMapId = mapItem.id;
+        this.selectedMapName = mapItem.name;
+    }
+
+    /**
+     * DeleteConfirmationDialogで削除ボタンが押されると呼び出され、
+     * 指定された詳細マップを削除するイベントを発火する。
+     */
+    @Emit('del')
+    private deleteMap() {
+        this.dialog = false;
+        return this.selectedMapId;
+    }
+
+    @Emit('dup')
+    private sendMapToDuplicate(mapId: number) {
+        return mapId;
+    }
+
+    /**
+     * DeleteConfirmationDialogでCancelボタンが押されると呼び出され、
+     * 削除確認ダイアログを閉じる。
+     */
+    private cancelMapDeletion() {
+        this.dialog = false;
     }
 }

--- a/src/components/TreeView/index.ts
+++ b/src/components/TreeView/index.ts
@@ -9,11 +9,37 @@ import Map from '@/Map/Map';
 })
 export default class TreeView extends Vue {
     @Prop()
-    private items: any;
+    private items!: any[];
     private tree = [];
     private dialog: boolean = false;
     private selectedMapId!: number;
     private selectedMapName: string = '';
+
+    private getItemFromKey(id: number, searchTarget: any[]): any {
+        for (const item of searchTarget) {
+            if (item.id === id) {
+                return item;
+            } else if (item.children !== undefined) {
+                const found = this.getItemFromKey(id, item.children);
+                if (found !== null) {
+                    return found;
+                }
+            }
+        }
+        return null;
+    }
+
+    private nodeClick(active: any[]) {
+        if (active.length === 0) {
+            return;
+        }
+        const item = this.getItemFromKey(active[0], this.items);
+        if (item.type === 'Map') {
+            this.sendMapToEdit(item.id);
+        } else if (item.type === 'Spot') {
+            this.sendSpotToEdit(item.id);
+        }
+    }
 
     @Emit('setMapToEdit')
     private sendMapToEdit(id: number) {

--- a/src/components/TreeView/index.ts
+++ b/src/components/TreeView/index.ts
@@ -1,0 +1,18 @@
+import { Component, Emit, Vue, Prop } from 'vue-property-decorator';
+
+@Component
+export default class TreeView extends Vue {
+    @Prop()
+    private items: any;
+    private tree = [];
+
+    @Emit('setMapToEdit')
+    private sendMapToEdit(id: number) {
+        return id;
+    }
+
+    @Emit('setSpotToEdit')
+    private sendSpotToEdit(id: number) {
+        return id;
+    }
+}

--- a/src/components/TreeView/index.vue
+++ b/src/components/TreeView/index.vue
@@ -9,39 +9,60 @@
             dense
         >
             <template v-slot:label="{ item }">
-                <div
-                    @click="item.type === 'Map'
-                    ? sendMapToEdit(item.id) 
-                    : sendSpotToEdit(item.id)"
-                    @mouseover="item.hovered = true"
-                    @mouseleave="item.hovered = false"
-                >
-                    {{ item.name }}
-                </div>
+                <v-hover v-slot:default="{ hover }">
+                    <div
+                        @click="item.type === 'Map'
+                        ? sendMapToEdit(item.id) 
+                        : sendSpotToEdit(item.id)"
+                    >
+                        <span>{{ item.name }}</span>
+                        <template v-if="item.type === 'Map' && item.id !== 0">
+                            <v-btn icon
+                                v-if="hover"
+                                @click.stop="confirmMapDeletion(item)"
+                            >
+                                <v-icon>delete</v-icon>
+                            </v-btn>
+                            <v-btn icon
+                                v-if="hover"
+                                @click.stop="sendMapToDuplicate(item.id)"
+                            >
+                                <v-icon>file_copy</v-icon>
+                            </v-btn>
+                        </template>
+                    </div>
+                </v-hover>
             </template>
             <template v-slot:prepend="{ item }">
                 <v-icon v-if="item.type==='Map'">
                     map
                 </v-icon>
                 <v-icon v-if="item.type==='Spot'">
-                    place
+                    {{ item.iconName }}
                 </v-icon>
             </template>
-            <template v-slot:append="{ item }">
-                <template v-if="item.hovered">
-                    <v-btn icon>
-                        <v-icon>file_copy</v-icon>
-                    </v-btn>
-                    <v-btn icon>
-                        <v-icon>delete</v-icon>
-                    </v-btn>
-                </template>
-            </template>
         </v-treeview>
+        <v-container id="delete-confirmation-dialog-container">
+            <v-dialog v-model="dialog" width="500">
+                <delete-confirmation-dialog
+                    class="delete-confirmation"
+                    :name="selectedMapName"
+                    @del="deleteMap"
+                    @cancel="cancelMapDeletion"
+                ></delete-confirmation-dialog>
+            </v-dialog>
+        </v-container>
     </div>
 </template>
 
 <script lang="ts" src="./index.ts"/>
 
 <style scoped>
+.appendRight {
+    float: right;
+}
+#delete-confirmation-dialog-container {
+  position: absolute;
+  z-index: 1100;
+}
 </style>

--- a/src/components/TreeView/index.vue
+++ b/src/components/TreeView/index.vue
@@ -1,0 +1,32 @@
+<template>
+    <div id="tree-view">
+        <v-treeview
+            hoverable
+            open-all
+            v-model="tree"
+            :items="items"
+            item-key="name"
+            dense
+        >
+            <template v-slot:prepend="{ item }">
+                <div
+                    @click="item.type === 'Map'
+                    ? sendMapToEdit(item.id) 
+                    : sendSpotToEdit(item.id)"
+                >
+                    <v-btn icon v-if="item.type==='Map'">
+                        <v-icon>map</v-icon>
+                    </v-btn>
+                    <v-btn icon v-if="item.type==='Spot'">
+                        <v-icon>place</v-icon>
+                    </v-btn>
+                </div>
+            </template>
+        </v-treeview>
+    </div>
+</template>
+
+<script lang="ts" src="./index.ts"/>
+
+<style scoped>
+</style>

--- a/src/components/TreeView/index.vue
+++ b/src/components/TreeView/index.vue
@@ -5,17 +5,16 @@
             open-all
             v-model="tree"
             :items="items"
-            item-key="name"
+            item-key="id"
             dense
+            activatable
+            @update:active="nodeClick"
         >
             <template v-slot:label="{ item }">
                 <v-hover v-slot:default="{ hover }">
-                    <div
-                        @click="item.type === 'Map'
-                        ? sendMapToEdit(item.id) 
-                        : sendSpotToEdit(item.id)"
-                    >
-                        <span>{{ item.name }}</span>
+                    <div>
+                        <span v-if="item.name.length < 10">{{ item.name }}</span>
+                        <span v-else>{{ item.name.substring(0, 10) }}...</span>
                         <template v-if="item.type === 'Map' && item.id !== 0">
                             <v-btn icon
                                 v-if="hover"

--- a/src/components/TreeView/index.vue
+++ b/src/components/TreeView/index.vue
@@ -8,19 +8,24 @@
             item-key="name"
             dense
         >
-            <template v-slot:prepend="{ item }">
+            <template v-slot:label="{ item }"
+            >
                 <div
                     @click="item.type === 'Map'
                     ? sendMapToEdit(item.id) 
                     : sendSpotToEdit(item.id)"
                 >
-                    <v-btn icon v-if="item.type==='Map'">
-                        <v-icon>map</v-icon>
-                    </v-btn>
-                    <v-btn icon v-if="item.type==='Spot'">
-                        <v-icon>place</v-icon>
-                    </v-btn>
+                    {{ item.name }}
                 </div>
+            </template>
+            <template v-slot:prepend="{ item }"
+            >
+                <v-btn icon v-if="item.type==='Map'">
+                    <v-icon>map</v-icon>
+                </v-btn>
+                <v-btn icon v-if="item.type==='Spot'">
+                    <v-icon>place</v-icon>
+                </v-btn>
             </template>
         </v-treeview>
     </div>

--- a/src/components/TreeView/index.vue
+++ b/src/components/TreeView/index.vue
@@ -8,24 +8,34 @@
             item-key="name"
             dense
         >
-            <template v-slot:label="{ item }"
-            >
+            <template v-slot:label="{ item }">
                 <div
                     @click="item.type === 'Map'
                     ? sendMapToEdit(item.id) 
                     : sendSpotToEdit(item.id)"
+                    @mouseover="item.hovered = true"
+                    @mouseleave="item.hovered = false"
                 >
                     {{ item.name }}
                 </div>
             </template>
-            <template v-slot:prepend="{ item }"
-            >
-                <v-btn icon v-if="item.type==='Map'">
-                    <v-icon>map</v-icon>
-                </v-btn>
-                <v-btn icon v-if="item.type==='Spot'">
-                    <v-icon>place</v-icon>
-                </v-btn>
+            <template v-slot:prepend="{ item }">
+                <v-icon v-if="item.type==='Map'">
+                    map
+                </v-icon>
+                <v-icon v-if="item.type==='Spot'">
+                    place
+                </v-icon>
+            </template>
+            <template v-slot:append="{ item }">
+                <template v-if="item.hovered">
+                    <v-btn icon>
+                        <v-icon>file_copy</v-icon>
+                    </v-btn>
+                    <v-btn icon>
+                        <v-icon>delete</v-icon>
+                    </v-btn>
+                </template>
             </template>
         </v-treeview>
     </div>

--- a/tests/unit/components/CreationMapView/CreationMapView.spec.ts
+++ b/tests/unit/components/CreationMapView/CreationMapView.spec.ts
@@ -10,6 +10,7 @@ import SpotMarker from '@/components/MapView/Marker/SpotMarker';
 import L, { Point } from 'leaflet';
 import SpotEditor from '@/components/SpotEditor';
 import Vuetify from 'vuetify';
+import TreeView from '@/components/TreeView';
 
 
 describe('components/CreationMapView', () => {
@@ -170,14 +171,17 @@ describe('components/CreationMapView', () => {
             topL: {lat: 0, lng: 0},
             botR: {lat: 0, lng: 0},
         };
-        const testDetailMap = new Map(0, 'testMap', testBounds);
+        const rootMap = new Map(0, 'testMap', testBounds);
+        const testDetailMap = new Map(1, 'testMap', testBounds);
         const testSpot = new Spot(0, 'testSpot', { lat: 0, lng: 0 });
 
+        wrapper.setData({map: rootMap});
         wrapper.setData({focusedSpot: testSpot});
-        const focusedSpot: Spot = wrapper.vm.focusedSpot;
-        expect(focusedSpot.getDetailMaps().length).toBe(0);
-        wrapper.find(SpotEditor).vm.$emit('dup', testDetailMap);
-        expect(focusedSpot.getDetailMaps().length).toBe(1);
+        rootMap.addSpot(testSpot);
+        testSpot.addDetailMaps([testDetailMap]);
+        expect(testSpot.getDetailMaps().length).toBe(1);
+        wrapper.find(TreeView).vm.$emit('dup', testDetailMap.getId());
+        expect(testSpot.getDetailMaps().length).toBe(2);
     });
 
     it('deleteDetailMapで詳細マップを削除', () => {
@@ -185,15 +189,16 @@ describe('components/CreationMapView', () => {
             topL: {lat: 0, lng: 0},
             botR: {lat: 0, lng: 0},
         };
-        const testDetailMap = new Map(0, 'testMap', testBounds);
+        const rootMap = new Map(0, 'testMap', testBounds);
+        const testDetailMap = new Map(1, 'testMap', testBounds);
         const testSpot = new Spot(0, 'testSpot', { lat: 0, lng: 0 });
         wrapper.setData({focusedSpot: testSpot});
-
-        const focusedSpot: Spot = wrapper.vm.focusedSpot;
-        focusedSpot.addDetailMaps([testDetailMap]);
-        expect(focusedSpot.getDetailMaps().length).toBe(1);
-        wrapper.find(SpotEditor).vm.$emit('del', testDetailMap.getId());
-        expect(focusedSpot.getDetailMaps().length).toBe(0);
+        wrapper.setData({map: rootMap});
+        testSpot.addDetailMaps([testDetailMap]);
+        rootMap.addSpot(testSpot);
+        expect(testSpot.getDetailMaps().length).toBe(1);
+        wrapper.find(TreeView).vm.$emit('del', testDetailMap.getId());
+        expect(testSpot.getDetailMaps().length).toBe(0);
     });
 
 });


### PR DESCRIPTION
## 実装の概要
- TreeViewの各項目をクリックした時にマップの場合は移動，スポットの場合はSpotEditorで表示+フォーカス
- TreeViewのマップの隣に複製・削除ボタンを追加(SpotEditorから移動)
- スポットのアイコンを各種種類によって変更
- treeviewの各nodeでどこを触っても反応するようになりました
- 長すぎるmap, spot名は10文字まで表示するように変更

## 問題点
- ~~マップ名が長いとTreeViewの複製・削除ボタンがはみ出る~~