### PR TITLE
詳細マップ追加時の挙動改善

### DIFF
--- a/src/components/CreationMapView/index.ts
+++ b/src/components/CreationMapView/index.ts
@@ -438,7 +438,7 @@ export default class CreationMapView extends Vue {
 
         this.focusedSpot!.addDetailMaps([newDetailMap]);
         newDetailMap.setParentSpot(this.focusedSpot!);
-
+        this.setMapToEdit(newDetailMap.getId());
     }
 
     /**

--- a/src/components/CreationMapView/index.ts
+++ b/src/components/CreationMapView/index.ts
@@ -303,7 +303,7 @@ export default class CreationMapView extends Vue {
      * マップクリック時に実行される関数を，形状描画メソッドにする
      * @param onShapeCreated 形状の作成が完了したときに呼び出す関数
      */
-    private setAddPointMethodOnMapClick(onShapeCreated: () => void): void {
+    private setAddPointMethodOnMapClick(onShapeCreated: () => void = () => undefined): void {
         this.shapeEditor.removeShapeEditLine();
         this.whileShapeEditing = true;
         if (this.leafletContainer !== null) {

--- a/src/components/CreationMapView/index.ts
+++ b/src/components/CreationMapView/index.ts
@@ -348,6 +348,16 @@ export default class CreationMapView extends Vue {
     }
 
     /**
+     * スポットエディターでスポットの範囲選択ボタンが押された際に実行
+     */
+    private  onClickShapeAddButton(): void {
+        this.whileShapeEditingForDetailMapAdding = false;
+        this.setAddPointMethodOnMapClick();
+    }
+
+    /**
+     * スポットのShape編集をキャンセル
+     * スポットエディタースポットの範囲選択がキャンセルされた際と，
      * 編集ツールバーコンボーネントでモードが切り替わった際に実行される
      */
     private cancelShapeEditMode() {
@@ -357,7 +367,22 @@ export default class CreationMapView extends Vue {
     }
 
     /**
-     * 詳細マップの追加（のための形状描画を）キャンセル
+     * スポットエディターでスポットの詳細マップ追加ボタンがクリックされた際に実行
+     */
+    private onClickDetailMapAddButton() {
+        if (this.focusedSpot!.getShape() === undefined) {
+            this.whileShapeEditingForDetailMapAdding = true;
+            this.setAddPointMethodOnMapClick(() => {
+                this.whileShapeEditingForDetailMapAdding = false;
+                this.addDetailMap();
+            });
+        } else {
+            this.addDetailMap();
+        }
+    }
+
+    /**
+     * 詳細マップの追加（のためのShape編集を）キャンセル
      */
     private cancelDetailMapAddMode() {
         this.whileShapeEditingForDetailMapAdding = false;
@@ -395,17 +420,6 @@ export default class CreationMapView extends Vue {
         mapViewMutations.setRootMap(this.rootMap);
     }
 
-    private onClickDetailMapAddButton() {
-        if (this.focusedSpot!.getShape() === undefined) {
-            this.whileShapeEditingForDetailMapAdding = true;
-            this.setAddPointMethodOnMapClick(() => {
-                this.whileShapeEditingForDetailMapAdding = false;
-                this.addDetailMap();
-            });
-        } else {
-            this.addDetailMap();
-        }
-    }
 
     /**
      * SpotEditorの詳細マップ追加ボタンをクリックすると呼ばれ、スポットに詳細マップを追加する。

--- a/src/components/CreationMapView/index.vue
+++ b/src/components/CreationMapView/index.vue
@@ -79,14 +79,14 @@
                   <SpotEditor
                     :isVisible="focusedSpot !== null"
                     @spotInput="updateFocusedMarkerName"
-                    :whileShapeEditing="whileShapeEditing"
                     :spot="focusedSpot"
-                    @clickAddShapeButton="setAddPointMethodOnMapClick"
+                    :whileShapeEditing="whileShapeEditing"
+                    :whileShapeEditingForDetailMapAdding="whileShapeEditingForDetailMapAdding"
+                    @clickAddShapeButton="onClickShapeAddButton"
                     @clickAddShapeCancelButton="cancelShapeEditMode"
-                    @delete="deleteFocusedSpot"
                     @clickDetailMapAddButton="onClickDetailMapAddButton"
                     @clickDetailMapAddCancelButton="cancelDetailMapAddMode"
-                    :whileShapeEditingForDetailMapAdding="whileShapeEditingForDetailMapAdding"
+                    @delete="deleteFocusedSpot"
                     @edit="editDetailMap"
                   />
                 </v-card>

--- a/src/components/CreationMapView/index.vue
+++ b/src/components/CreationMapView/index.vue
@@ -84,7 +84,9 @@
                     @clickAddShapeButton="setAddPointMethodOnMapClick"
                     @clickAddShapeCancelButton="cancelShapeEditMode"
                     @delete="deleteFocusedSpot"
-                    @add="addDetailMap"
+                    @clickDetailMapAddButton="onClickDetailMapAddButton"
+                    @clickDetailMapAddCancelButton="cancelDetailMapAddMode"
+                    :whileShapeEditingForDetailMapAdding="whileShapeEditingForDetailMapAdding"
                     @edit="editDetailMap"
                   />
                 </v-card>
@@ -161,7 +163,7 @@
                   @clickZoomOut="zoomOut"
                   @clickSelect="setDefaultMethodOnMapClick"
                   @clickSpot="setAddSpotMethodOnMapClick"
-                  @switchMode="cancelShapeEditMode"
+                  @switchMode="cancelDetailMapAddMode"
                   :spotButtonIsVisible="spotButtonInEditorToolBarIsVisible"
                   :shapeEditButtonIsVisible="shapeEditButtonIsVisible"
                 />

--- a/src/components/SpotEditor/index.ts
+++ b/src/components/SpotEditor/index.ts
@@ -25,11 +25,11 @@ export default class SpotEditor extends Vue {
     private attachment: [{name: string, url: string}] = [{name: '', url: ''}];
     private dialog: boolean = false;
 
-    mounted() {
+    public mounted() {
         this.$watch(
             () => [this.whileShapeEditing, this.whileShapeEditingForDetailMapAdding],
             this.switchShapeAddButtonName,
-        )
+        );
     }
 
     /**
@@ -80,7 +80,6 @@ export default class SpotEditor extends Vue {
     }
 
     private switchShapeAddButtonName(): void {
-        console.log(this.whileShapeEditingForDetailMapAdding);
         if (this.whileShapeEditing && !this.whileShapeEditingForDetailMapAdding) {
             this.shapeAddButtonName = 'キャンセル';
             this.shapeAddIconIsVisible = false;

--- a/src/components/SpotEditor/index.ts
+++ b/src/components/SpotEditor/index.ts
@@ -90,7 +90,7 @@ export default class SpotEditor extends Vue {
     }
 
     private onClickShapeAddButton(): void {
-        if (this.whileShapeEditing) {
+        if (this.whileShapeEditing && !this.whileShapeEditingForDetailMapAdding) {
             this.$emit('clickAddShapeCancelButton');
         } else {
             this.$emit('clickAddShapeButton');

--- a/src/components/SpotEditor/index.ts
+++ b/src/components/SpotEditor/index.ts
@@ -17,16 +17,31 @@ export default class SpotEditor extends Vue {
     public isVisible!: boolean;
     @Prop()
     public whileShapeEditing!: boolean;
+    @Prop()
+    public whileShapeEditingForDetailMapAdding!: boolean;
+    private shapeAddIconIsVisible = true;
+    private detailMapAddButtonName: '詳細マップ' | 'キャンセル' = '詳細マップ';
     private shapeAddButtonName: '範囲選択' | 'キャンセル' = '範囲選択';
     private attachment: [{name: string, url: string}] = [{name: '', url: ''}];
     private dialog: boolean = false;
+
+    mounted() {
+        this.$watch(
+            () => [this.whileShapeEditing, this.whileShapeEditingForDetailMapAdding],
+            this.switchShapeAddButtonName,
+        )
+    }
 
     /**
      * DetailMapManageListから詳細マップ追加のイベントが発火されると呼び出され、
      * 詳細マップ追加のイベントを発火する。
      */
-    private addDetailMap(): void {
-        this.$emit('add');
+    private onClickDetailMapAddButton(): void {
+        if (this.whileShapeEditingForDetailMapAdding) {
+            this.$emit('clickDetailMapAddCancelButton');
+        } else {
+            this.$emit('clickDetailMapAddButton');
+        }
     }
 
     /**
@@ -64,12 +79,14 @@ export default class SpotEditor extends Vue {
         }
     }
 
-    @Watch('whileShapeEditing')
     private switchShapeAddButtonName(): void {
-        if (this.whileShapeEditing) {
+        console.log(this.whileShapeEditingForDetailMapAdding);
+        if (this.whileShapeEditing && !this.whileShapeEditingForDetailMapAdding) {
             this.shapeAddButtonName = 'キャンセル';
+            this.shapeAddIconIsVisible = false;
         } else {
             this.shapeAddButtonName = '範囲選択';
+            this.shapeAddIconIsVisible = true;
         }
     }
 
@@ -81,4 +98,12 @@ export default class SpotEditor extends Vue {
         }
     }
 
+    @Watch('whileShapeEditingForDetailMapAdding')
+    private switchDetailMapAddButtonName(): void {
+        if (this.whileShapeEditingForDetailMapAdding) {
+            this.detailMapAddButtonName = 'キャンセル';
+        } else {
+            this.detailMapAddButtonName = '詳細マップ';
+        }
+    }
 }

--- a/src/components/SpotEditor/index.vue
+++ b/src/components/SpotEditor/index.vue
@@ -36,7 +36,7 @@
           outlined
           @click="onClickShapeAddButton()"
         >
-          <v-icon left v-show="!whileShapeEditing">{{ shapeAddButtonIcon() }}</v-icon>
+          <v-icon left v-show="shapeAddIconIsVisible">{{ shapeAddButtonIcon() }}</v-icon>
           <span>{{ shapeAddButtonName }}</span>
         </v-btn>
         <v-spacer></v-spacer>
@@ -55,11 +55,10 @@
           color="#3fa590"
           block
           outlined
-          :disabled="spot.getShape() === undefined"
-          @click="addDetailMap"
+          @click="onClickDetailMapAddButton()"
         >
-          <v-icon left>add</v-icon>
-          <span>詳細マップ</span>
+          <v-icon left v-show="!whileShapeEditingForDetailMapAdding">add</v-icon>
+          <span>{{ detailMapAddButtonName }}</span>
         </v-btn>
       </v-card-actions>
       <v-container id="delete-confirmation-dialog-container">

--- a/src/components/TreeView/index.vue
+++ b/src/components/TreeView/index.vue
@@ -40,13 +40,23 @@
                                 v-if="hover"
                                 @click.stop="confirmMapDeletion(item)"
                             >
-                                <v-icon>delete</v-icon>
+                                <v-tooltip id="tooltip" bottom>
+                                    <template v-slot:activator="{ on, attrs }">
+                                        <v-icon v-bind="attrs" v-on="on">delete</v-icon>
+                                    </template>
+                                    <span>削除</span>
+                                </v-tooltip>
                             </v-btn>
                             <v-btn icon
                                 v-if="hover"
                                 @click.stop="sendMapToDuplicate(item.id)"
                             >
-                                <v-icon>file_copy</v-icon>
+                                <v-tooltip id="tooltip" bottom>
+                                    <template v-slot:activator="{ on, attrs }">
+                                        <v-icon v-bind="attrs" v-on="on">file_copy</v-icon>
+                                    </template>
+                                    <span>複製</span>
+                                </v-tooltip>
                             </v-btn>
                         </template>
                     </div>
@@ -82,6 +92,9 @@
 }
 #delete-confirmation-dialog-container {
   position: absolute;
+  z-index: 1100;
+}
+#tooltip {
   z-index: 1100;
 }
 </style>

--- a/tests/unit/components/CreationMapView/CreationMapView.spec.ts
+++ b/tests/unit/components/CreationMapView/CreationMapView.spec.ts
@@ -11,6 +11,7 @@ import L, { Point } from 'leaflet';
 import SpotEditor from '@/components/SpotEditor';
 import Vuetify from 'vuetify';
 import TreeView from '@/components/TreeView';
+import ShapeEditor from '@/components/CreationMapView/ShapeEditor';
 
 
 describe('components/CreationMapView', () => {
@@ -138,7 +139,6 @@ describe('components/CreationMapView', () => {
             topL: {lat: 0, lng: 0},
             botR: {lat: 0, lng: 0},
         };
-        const testDetailMap = new Map(0, 'testMap', testBounds);
         const testSpot = new Spot(
             0,
             'testSpot',
@@ -149,20 +149,23 @@ describe('components/CreationMapView', () => {
                     [
                         [130.21791636943817, 33.59517952985549],
                         [130.21812558174133, 33.59524208725731],
-                        [130.2181041240692, 33.595291239469766],
+                        [130.2181041240692,  33.595291239469766],
                         [130.21862983703613, 33.595465506179146],
-                        [130.2184957265854, 33.59572913976256],
-                        [130.2177768945694, 33.59551018989406],
+                        [130.2184957265854,  33.59572913976256],
+                        [130.2177768945694,  33.59551018989406],
                         [130.21791636943817, 33.59517952985549],
                     ],
                 ],
             },
         );
+        (wrapper.vm.rootMap as Map).addSpot(testSpot);
         wrapper.setData({focusedSpot: testSpot});
+        (wrapper.vm.shapeEditor as ShapeEditor).displayPolygons = jest.fn();
+        (wrapper.vm.shapeEditor as ShapeEditor).addPolygonLine = jest.fn();
 
         const focusedSpot: Spot = wrapper.vm.focusedSpot;
         expect(focusedSpot.getDetailMaps().length).toBe(0);
-        wrapper.find(SpotEditor).vm.$emit('add');
+        wrapper.find(SpotEditor).vm.$emit('clickDetailMapAddButton');
         expect(focusedSpot.getDetailMaps().length).toBe(1);
     });
 


### PR DESCRIPTION
## 実装の概要
- 詳細マップ追加ボタンをデフォルトでonに
- 詳細マップ追加ボタンをクリック時にスポットの範囲が登録されていない場合，描画モードに移行
- 詳細マップ追加時に自動で詳細マップに遷移
