### PR TITLE
削除ダイアログコンポーネントの作成

### DIFF
--- a/src/components/DeleteConfirmationDialog/index.ts
+++ b/src/components/DeleteConfirmationDialog/index.ts
@@ -1,0 +1,21 @@
+import { Component, Vue, Prop } from 'vue-property-decorator';
+
+@Component
+export default class DeleteConfirmationDialog extends Vue {
+    @Prop() public name!: string;
+
+    /**
+     * 削除ボタンを押すと呼び出され、削除イベントを発火する。
+     */
+    private confirmedDeletion(): void {
+        this.$emit('del');
+    }
+
+    /**
+     * キャンセルボタンを押すと呼び出され、キャンセルイベントを発火する。
+     */
+    private cancelDeletion(): void {
+        this.$emit('cancel');
+    }
+
+}

--- a/src/components/DeleteConfirmationDialog/index.vue
+++ b/src/components/DeleteConfirmationDialog/index.vue
@@ -1,0 +1,35 @@
+<template>
+  <v-card>
+    <v-card-title
+      class="headline"
+      primary-title
+    >
+      {{ name }}を削除しますか？
+    </v-card-title>
+    <v-divider></v-divider>
+    <v-card-actions>
+      <v-btn
+        class="cancel"
+        color="primary"
+        text
+        @click="cancelDeletion"
+      >
+        Cancel
+      </v-btn>
+      <v-spacer></v-spacer>
+      <v-btn
+        class="delete"
+        text
+        color="warning"
+        @click="confirmedDeletion"
+      >
+        Delete
+      </v-btn>
+    </v-card-actions>
+  </v-card>
+</template>
+
+<script lang="ts" src="./index.ts"/>
+
+<style scoped>
+</style>

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -28,6 +28,25 @@
                                 <span class="white--text">地図作成</span>
                             </v-btn>
                         </div>
+                        <!-- <div class="my-2">
+                             <v-btn
+                                icon
+                                @click="dialog = true"
+                                >
+                                <v-icon>delete</v-icon>
+                            </v-btn>
+                            <v-dialog
+                                v-model="dialog"
+                                width="500"
+                            >
+                            <delete-confirmation-dialog
+                                class="delete-confirmation"
+                                :name="testName"
+                                @del="deleteMap"
+                                @cancel="dialog = false"
+                            ></delete-confirmation-dialog>
+                            </v-dialog>
+                        </div> -->
                     </v-col>
                 </v-row>
             </v-container>
@@ -38,12 +57,15 @@
 <script lang='ts'>
 import { Vue, Component } from 'vue-property-decorator';
 import Menu from '@/components/Menu/index.vue';
+// import DeleteConfirmationDialog from '@/components/DeleteConfirmationDialog/index.vue';
 
 @Component({
     components: {
         Menu,
+        // DeleteConfirmationDialog,
     },
 })
 export default class Home extends Vue {
+    // private dialog: boolean = false;
 }
 </script>

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -28,7 +28,7 @@
                                 <span class="white--text">地図作成</span>
                             </v-btn>
                         </div>
-                        <div>
+                        <!-- <div>
                              <v-btn
                                 icon
                                 @click="dialog = true"
@@ -41,12 +41,12 @@
                             >
                             <delete-confirmation-dialog
                                 class="delete-confirmation"
-                                :name="'testName'"
+                                :name="' '"
                                 @del="dialog = false"
                                 @cancel="dialog = false"
                             ></delete-confirmation-dialog>
                             </v-dialog>
-                        </div>
+                        </div> -->
                     </v-col>
                 </v-row>
             </v-container>
@@ -57,15 +57,15 @@
 <script lang='ts'>
 import { Vue, Component } from 'vue-property-decorator';
 import Menu from '@/components/Menu/index.vue';
-import DeleteConfirmationDialog from '@/components/DeleteConfirmationDialog/index.vue';
+// import DeleteConfirmationDialog from '@/components/DeleteConfirmationDialog/index.vue';
 
 @Component({
     components: {
         Menu,
-        DeleteConfirmationDialog,
+        // DeleteConfirmationDialog,
     },
 })
 export default class Home extends Vue {
-    private dialog: boolean = false;
+    // private dialog: boolean = false;
 }
 </script>

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -28,7 +28,7 @@
                                 <span class="white--text">地図作成</span>
                             </v-btn>
                         </div>
-                        <!-- <div class="my-2">
+                        <div>
                              <v-btn
                                 icon
                                 @click="dialog = true"
@@ -41,12 +41,12 @@
                             >
                             <delete-confirmation-dialog
                                 class="delete-confirmation"
-                                :name="testName"
-                                @del="deleteMap"
+                                :name="'testName'"
+                                @del="dialog = false"
                                 @cancel="dialog = false"
                             ></delete-confirmation-dialog>
                             </v-dialog>
-                        </div> -->
+                        </div>
                     </v-col>
                 </v-row>
             </v-container>
@@ -57,15 +57,15 @@
 <script lang='ts'>
 import { Vue, Component } from 'vue-property-decorator';
 import Menu from '@/components/Menu/index.vue';
-// import DeleteConfirmationDialog from '@/components/DeleteConfirmationDialog/index.vue';
+import DeleteConfirmationDialog from '@/components/DeleteConfirmationDialog/index.vue';
 
 @Component({
     components: {
         Menu,
-        // DeleteConfirmationDialog,
+        DeleteConfirmationDialog,
     },
 })
 export default class Home extends Vue {
-    // private dialog: boolean = false;
+    private dialog: boolean = false;
 }
 </script>

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -1,6 +1,6 @@
 <template>
     <Menu>
-        <v-content>
+        <v-main>
             <v-container
                 class="fill-height"
                 fluid
@@ -50,7 +50,7 @@
                     </v-col>
                 </v-row>
             </v-container>
-        </v-content>
+        </v-main>
     </Menu>
 </template>
 

--- a/tests/unit/components/DeleteConfirmationDialog/DeleteConfirmationDialog.spec.ts
+++ b/tests/unit/components/DeleteConfirmationDialog/DeleteConfirmationDialog.spec.ts
@@ -1,0 +1,37 @@
+import { createLocalVue, shallowMount, mount } from '@vue/test-utils';
+import DeleteConfirmationDialog from '@/components/DeleteConfirmationDialog/index.vue';
+import Vuetify from 'vuetify';
+
+describe('DeleteConfirmationDialogのテスト', () => {
+    let localVue: any;
+    let wrapper: any;
+    let vuetify: any;
+
+    beforeEach(() => {
+        vuetify = new Vuetify();
+        localVue = createLocalVue();
+        localVue.use(Vuetify);
+        wrapper = mount( DeleteConfirmationDialog, {
+            localVue,
+            vuetify,
+        });
+    });
+
+    it('propで受け取った文字列を受け取る', () => {
+        wrapper.setProps({
+            name: 'testName',
+        });
+        expect(wrapper.vm.$props.name).toBe('testName');
+    });
+
+    it('削除ボタンを押すと削除イベントが発火される', () => {
+        wrapper.find('.v-btn.delete').trigger('click');
+        expect(wrapper.emitted().del).toBeTruthy();
+    });
+
+    it('キャンセルボタンを押すとキャンセルイベントが発火される', () => {
+        wrapper.find('.v-btn.cancel').trigger('click');
+        expect(wrapper.emitted().cancel).toBeTruthy();
+    });
+
+});


### PR DESCRIPTION
## 実装の概要
削除ダイアログの作成

Home.Vueの31～49,60,65,69のコメントアウトを解除するとHomeの地図利用・作成ボタンの下にゴミ箱のアイコンが出るので、それをクリックしてもらうと削除ダイアログが表示されるようになっています。
削除ダイアログでは今は何も削除せずに、delete・cancelどちらをしてもダイアログを非表示するだけとなっています。

close #412
